### PR TITLE
protocol: remove untrusted peers

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ for (const message of messages.slice().reverse()) {
 
 Create read-only channel using its public key obtained elsewhere:
 ```js
-cosnt channel = await vowLink.channelFromPublicKey(
+cosnt feed = await vowLink.feedFromPublicKey(
   publicKey,
   { name: 'channel-name' });
 ```

--- a/examples/repl-chat/lib/chat.js
+++ b/examples/repl-chat/lib/chat.js
@@ -207,8 +207,7 @@ export default class Chat {
 
       return name;
     });
-    const time = new Date(message.content.timestamp * 1000)
-      .toLocaleTimeString();
+    const time = new Date(message.timestamp * 1000).toLocaleTimeString();
     const author = displayPath.join('>');
 
     let text;

--- a/examples/repl-chat/package-lock.json
+++ b/examples/repl-chat/package-lock.json
@@ -106,14 +106,14 @@
       "integrity": "sha512-1w52Nyx4Gq47uuu0EVcsHBxZFJgurQ+rTKS3qMHxR1GY2T8c2AJYd6vZoZ9q1rupaDjU0yT+Jc2XTyXkjeMA+Q=="
     },
     "@types/node": {
-      "version": "10.14.16",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.16.tgz",
-      "integrity": "sha512-/opXIbfn0P+VLt+N8DE4l8Mn8rbhiJgabU96ZJ0p9mxOkIks5gh6RUnpHak7Yh0SFkyjO/ODbxsQQPV2bpMmyA=="
+      "version": "10.14.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.17.tgz",
+      "integrity": "sha512-p/sGgiPaathCfOtqu2fx5Mu1bcjuP8ALFg4xpGgNkcin7LwRyzUKniEHBKdcE1RPsenq5JVPIpMTJSygLboygQ=="
     },
     "@vowlink/protocol": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@vowlink/protocol/-/protocol-4.1.0.tgz",
-      "integrity": "sha512-3KITkV1W3zl6sl4Dj2Uf7tRUYtGIRq2bMdxCx3Op3vZxa1hZbPsb6xFZ/MRyUlva/OXwRObTV1EzT2WQMCfReA==",
+      "version": "5.0.0-0",
+      "resolved": "https://registry.npmjs.org/@vowlink/protocol/-/protocol-5.0.0-0.tgz",
+      "integrity": "sha512-KJM1v2M5R9eP9dpnsTwnsr7hWKd0uIKstZQG1XGGk7M265D6mIEpECQBQiYZbsx0atbFXlM1cAYo5dwmenC4Aw==",
       "requires": {
         "debug": "^4.1.1",
         "promise-waitlist": "^1.3.0",
@@ -122,17 +122,17 @@
       }
     },
     "@vowlink/sqlite-storage": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@vowlink/sqlite-storage/-/sqlite-storage-1.2.0.tgz",
-      "integrity": "sha512-9rh9aePCuM1PaQkosBOpAbmjCd4tXS2I2qTZV3AfZSnxBBuCRl02VK4x9mC3MixRpkX5WLOcJCHF4EFdnJVtNA==",
+      "version": "2.0.0-0",
+      "resolved": "https://registry.npmjs.org/@vowlink/sqlite-storage/-/sqlite-storage-2.0.0-0.tgz",
+      "integrity": "sha512-qTnJTdic09e8GcmzgtkOO0WJdhRpaqgrAWhlUome3OKfA2TKbQW4ciBSWmPc8RVr7JPxxurfN8MG2PPUsMROmg==",
       "requires": {
         "sqlite3": "^4.0.9"
       }
     },
     "@vowlink/swarm": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@vowlink/swarm/-/swarm-2.0.0.tgz",
-      "integrity": "sha512-J4HKqPNuDgEdFpHUnh5gDKEOmLvLZOTsq4YMkZZxJmpN9fLcdhBdtWBT1rVO+gfAagznk4WclUR2jVDqjOlS9w==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@vowlink/swarm/-/swarm-2.0.4.tgz",
+      "integrity": "sha512-LZOEeVjUFJOre4urEQuyZ5vwwtJOS0ovz+2s3QQtKhxiNOpWeViZJ5RvP/ujhkiTGDDUKweGO9kmeQ7vo4wQQA==",
       "requires": {
         "debug": "^4.1.1",
         "hyperswarm": "^2.0.6",
@@ -501,9 +501,9 @@
       }
     },
     "hyperswarm": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/hyperswarm/-/hyperswarm-2.0.6.tgz",
-      "integrity": "sha512-TJ0ZKNRbzFUiX4qZ+2dbmcUeUlZ+Ie+8h+1rOnklI9FQidoAELT/p5YhgPTzSFwkVh4b1lgcofJku3e6/FlJNA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/hyperswarm/-/hyperswarm-2.1.0.tgz",
+      "integrity": "sha512-wLglMq3vNlgxEXrtf1nMhKoVwDjgHjuU/6mFqmezBoCltqiltFGVE59DbRpFD2O/4dvFop4vli8dBPN/tsPRvg==",
       "requires": {
         "@hyperswarm/discovery": "^1.1.0",
         "@hyperswarm/network": "1.0.0",
@@ -520,9 +520,9 @@
       }
     },
     "ignore-walk": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
-      "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.2.tgz",
+      "integrity": "sha512-EXyErtpHbn75ZTsOADsfx6J/FPo6/5cjev46PXrcTpd8z3BoRkXgYu9/JVqrI7tusjmwCZutGeRJeU0Wo1e4Cw==",
       "requires": {
         "minimatch": "^3.0.4"
       }
@@ -877,9 +877,9 @@
       }
     },
     "psl": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.3.0.tgz",
-      "integrity": "sha512-avHdspHO+9rQTLbv1RO+MPYeP/SzsCoxofjVnHanETfQhTJrmB0HlDoW+EiN/R+C0BZ+gERab9NY0lPN2TxNag=="
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.3.1.tgz",
+      "integrity": "sha512-2KLd5fKOdAfShtY2d/8XDWVRnmp3zp40Qt6ge2zBPFARLXOGUf2fHD5eg+TV/5oxBtQKVhjUaKFsAaE4HnwfSA=="
     },
     "punycode": {
       "version": "2.1.1",

--- a/examples/repl-chat/package-lock.json
+++ b/examples/repl-chat/package-lock.json
@@ -111,9 +111,9 @@
       "integrity": "sha512-p/sGgiPaathCfOtqu2fx5Mu1bcjuP8ALFg4xpGgNkcin7LwRyzUKniEHBKdcE1RPsenq5JVPIpMTJSygLboygQ=="
     },
     "@vowlink/protocol": {
-      "version": "5.0.0-0",
-      "resolved": "https://registry.npmjs.org/@vowlink/protocol/-/protocol-5.0.0-0.tgz",
-      "integrity": "sha512-KJM1v2M5R9eP9dpnsTwnsr7hWKd0uIKstZQG1XGGk7M265D6mIEpECQBQiYZbsx0atbFXlM1cAYo5dwmenC4Aw==",
+      "version": "5.0.0-2",
+      "resolved": "https://registry.npmjs.org/@vowlink/protocol/-/protocol-5.0.0-2.tgz",
+      "integrity": "sha512-w+xQfbyGHlchWK8DnT3K3zlMPY9YgLPYbUBe+HBKIIMUer/ZtQ4dIUa+cEsOLfBqCVWlhQpWQpkRdowx1ePL8g==",
       "requires": {
         "debug": "^4.1.1",
         "promise-waitlist": "^1.3.0",

--- a/examples/repl-chat/package.json
+++ b/examples/repl-chat/package.json
@@ -14,9 +14,9 @@
   "license": "MIT",
   "description": "",
   "dependencies": {
-    "@vowlink/protocol": "^4.1.0",
-    "@vowlink/sqlite-storage": "^1.2.0",
-    "@vowlink/swarm": "^2.0.0",
+    "@vowlink/protocol": "^5.0.0-0",
+    "@vowlink/sqlite-storage": "^2.0.0-0",
+    "@vowlink/swarm": "^2.0.4",
     "bs58": "^4.0.1",
     "esm": "^3.2.25",
     "sodium-universal": "^2.0.0"

--- a/examples/repl-chat/package.json
+++ b/examples/repl-chat/package.json
@@ -14,7 +14,7 @@
   "license": "MIT",
   "description": "",
   "dependencies": {
-    "@vowlink/protocol": "^5.0.0-0",
+    "@vowlink/protocol": "^5.0.0-2",
     "@vowlink/sqlite-storage": "^2.0.0-0",
     "@vowlink/swarm": "^2.0.4",
     "bs58": "^4.0.1",

--- a/lib/messages.js
+++ b/lib/messages.js
@@ -2645,11 +2645,11 @@ export const ChannelMessage = $root.ChannelMessage = (() => {
              * Properties of a TBS.
              * @memberof ChannelMessage.Content
              * @interface ITBS
+             * @property {Array.<Uint8Array>|null} [parents] TBS parents
+             * @property {number|Long|null} [height] TBS height
              * @property {Array.<ILink>|null} [chain] TBS chain
              * @property {number|null} [timestamp] TBS timestamp
              * @property {ChannelMessage.IBody|null} [body] TBS body
-             * @property {Array.<Uint8Array>|null} [parents] TBS parents
-             * @property {number|Long|null} [height] TBS height
              */
 
             /**
@@ -2661,13 +2661,29 @@ export const ChannelMessage = $root.ChannelMessage = (() => {
              * @param {ChannelMessage.Content.ITBS=} [properties] Properties to set
              */
             function TBS(properties) {
-                this.chain = [];
                 this.parents = [];
+                this.chain = [];
                 if (properties)
                     for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
                         if (properties[keys[i]] != null)
                             this[keys[i]] = properties[keys[i]];
             }
+
+            /**
+             * TBS parents.
+             * @member {Array.<Uint8Array>} parents
+             * @memberof ChannelMessage.Content.TBS
+             * @instance
+             */
+            TBS.prototype.parents = $util.emptyArray;
+
+            /**
+             * TBS height.
+             * @member {number|Long} height
+             * @memberof ChannelMessage.Content.TBS
+             * @instance
+             */
+            TBS.prototype.height = $util.Long ? $util.Long.fromBits(0,0,false) : 0;
 
             /**
              * TBS chain.
@@ -2694,22 +2710,6 @@ export const ChannelMessage = $root.ChannelMessage = (() => {
             TBS.prototype.body = null;
 
             /**
-             * TBS parents.
-             * @member {Array.<Uint8Array>} parents
-             * @memberof ChannelMessage.Content.TBS
-             * @instance
-             */
-            TBS.prototype.parents = $util.emptyArray;
-
-            /**
-             * TBS height.
-             * @member {number|Long} height
-             * @memberof ChannelMessage.Content.TBS
-             * @instance
-             */
-            TBS.prototype.height = $util.Long ? $util.Long.fromBits(0,0,false) : 0;
-
-            /**
              * Creates a new TBS instance using the specified properties.
              * @function create
              * @memberof ChannelMessage.Content.TBS
@@ -2733,18 +2733,18 @@ export const ChannelMessage = $root.ChannelMessage = (() => {
             TBS.encode = function encode(message, writer) {
                 if (!writer)
                     writer = $Writer.create();
-                if (message.chain != null && message.chain.length)
-                    for (let i = 0; i < message.chain.length; ++i)
-                        $root.Link.encode(message.chain[i], writer.uint32(/* id 1, wireType 2 =*/10).fork()).ldelim();
-                if (message.timestamp != null && message.hasOwnProperty("timestamp"))
-                    writer.uint32(/* id 2, wireType 1 =*/17).double(message.timestamp);
-                if (message.body != null && message.hasOwnProperty("body"))
-                    $root.ChannelMessage.Body.encode(message.body, writer.uint32(/* id 3, wireType 2 =*/26).fork()).ldelim();
                 if (message.parents != null && message.parents.length)
                     for (let i = 0; i < message.parents.length; ++i)
-                        writer.uint32(/* id 4, wireType 2 =*/34).bytes(message.parents[i]);
+                        writer.uint32(/* id 1, wireType 2 =*/10).bytes(message.parents[i]);
                 if (message.height != null && message.hasOwnProperty("height"))
-                    writer.uint32(/* id 5, wireType 0 =*/40).int64(message.height);
+                    writer.uint32(/* id 2, wireType 0 =*/16).int64(message.height);
+                if (message.chain != null && message.chain.length)
+                    for (let i = 0; i < message.chain.length; ++i)
+                        $root.Link.encode(message.chain[i], writer.uint32(/* id 3, wireType 2 =*/26).fork()).ldelim();
+                if (message.timestamp != null && message.hasOwnProperty("timestamp"))
+                    writer.uint32(/* id 4, wireType 1 =*/33).double(message.timestamp);
+                if (message.body != null && message.hasOwnProperty("body"))
+                    $root.ChannelMessage.Body.encode(message.body, writer.uint32(/* id 5, wireType 2 =*/42).fork()).ldelim();
                 return writer;
             };
 
@@ -2780,23 +2780,23 @@ export const ChannelMessage = $root.ChannelMessage = (() => {
                     let tag = reader.uint32();
                     switch (tag >>> 3) {
                     case 1:
-                        if (!(message.chain && message.chain.length))
-                            message.chain = [];
-                        message.chain.push($root.Link.decode(reader, reader.uint32()));
-                        break;
-                    case 2:
-                        message.timestamp = reader.double();
-                        break;
-                    case 3:
-                        message.body = $root.ChannelMessage.Body.decode(reader, reader.uint32());
-                        break;
-                    case 4:
                         if (!(message.parents && message.parents.length))
                             message.parents = [];
                         message.parents.push(reader.bytes());
                         break;
-                    case 5:
+                    case 2:
                         message.height = reader.int64();
+                        break;
+                    case 3:
+                        if (!(message.chain && message.chain.length))
+                            message.chain = [];
+                        message.chain.push($root.Link.decode(reader, reader.uint32()));
+                        break;
+                    case 4:
+                        message.timestamp = reader.double();
+                        break;
+                    case 5:
+                        message.body = $root.ChannelMessage.Body.decode(reader, reader.uint32());
                         break;
                     default:
                         reader.skipType(tag & 7);
@@ -2833,6 +2833,16 @@ export const ChannelMessage = $root.ChannelMessage = (() => {
             TBS.verify = function verify(message) {
                 if (typeof message !== "object" || message === null)
                     return "object expected";
+                if (message.parents != null && message.hasOwnProperty("parents")) {
+                    if (!Array.isArray(message.parents))
+                        return "parents: array expected";
+                    for (let i = 0; i < message.parents.length; ++i)
+                        if (!(message.parents[i] && typeof message.parents[i].length === "number" || $util.isString(message.parents[i])))
+                            return "parents: buffer[] expected";
+                }
+                if (message.height != null && message.hasOwnProperty("height"))
+                    if (!$util.isInteger(message.height) && !(message.height && $util.isInteger(message.height.low) && $util.isInteger(message.height.high)))
+                        return "height: integer|Long expected";
                 if (message.chain != null && message.hasOwnProperty("chain")) {
                     if (!Array.isArray(message.chain))
                         return "chain: array expected";
@@ -2850,16 +2860,6 @@ export const ChannelMessage = $root.ChannelMessage = (() => {
                     if (error)
                         return "body." + error;
                 }
-                if (message.parents != null && message.hasOwnProperty("parents")) {
-                    if (!Array.isArray(message.parents))
-                        return "parents: array expected";
-                    for (let i = 0; i < message.parents.length; ++i)
-                        if (!(message.parents[i] && typeof message.parents[i].length === "number" || $util.isString(message.parents[i])))
-                            return "parents: buffer[] expected";
-                }
-                if (message.height != null && message.hasOwnProperty("height"))
-                    if (!$util.isInteger(message.height) && !(message.height && $util.isInteger(message.height.low) && $util.isInteger(message.height.high)))
-                        return "height: integer|Long expected";
                 return null;
             };
 
@@ -2875,23 +2875,6 @@ export const ChannelMessage = $root.ChannelMessage = (() => {
                 if (object instanceof $root.ChannelMessage.Content.TBS)
                     return object;
                 let message = new $root.ChannelMessage.Content.TBS();
-                if (object.chain) {
-                    if (!Array.isArray(object.chain))
-                        throw TypeError(".ChannelMessage.Content.TBS.chain: array expected");
-                    message.chain = [];
-                    for (let i = 0; i < object.chain.length; ++i) {
-                        if (typeof object.chain[i] !== "object")
-                            throw TypeError(".ChannelMessage.Content.TBS.chain: object expected");
-                        message.chain[i] = $root.Link.fromObject(object.chain[i]);
-                    }
-                }
-                if (object.timestamp != null)
-                    message.timestamp = Number(object.timestamp);
-                if (object.body != null) {
-                    if (typeof object.body !== "object")
-                        throw TypeError(".ChannelMessage.Content.TBS.body: object expected");
-                    message.body = $root.ChannelMessage.Body.fromObject(object.body);
-                }
                 if (object.parents) {
                     if (!Array.isArray(object.parents))
                         throw TypeError(".ChannelMessage.Content.TBS.parents: array expected");
@@ -2911,6 +2894,23 @@ export const ChannelMessage = $root.ChannelMessage = (() => {
                         message.height = object.height;
                     else if (typeof object.height === "object")
                         message.height = new $util.LongBits(object.height.low >>> 0, object.height.high >>> 0).toNumber();
+                if (object.chain) {
+                    if (!Array.isArray(object.chain))
+                        throw TypeError(".ChannelMessage.Content.TBS.chain: array expected");
+                    message.chain = [];
+                    for (let i = 0; i < object.chain.length; ++i) {
+                        if (typeof object.chain[i] !== "object")
+                            throw TypeError(".ChannelMessage.Content.TBS.chain: object expected");
+                        message.chain[i] = $root.Link.fromObject(object.chain[i]);
+                    }
+                }
+                if (object.timestamp != null)
+                    message.timestamp = Number(object.timestamp);
+                if (object.body != null) {
+                    if (typeof object.body !== "object")
+                        throw TypeError(".ChannelMessage.Content.TBS.body: object expected");
+                    message.body = $root.ChannelMessage.Body.fromObject(object.body);
+                }
                 return message;
             };
 
@@ -2928,27 +2928,18 @@ export const ChannelMessage = $root.ChannelMessage = (() => {
                     options = {};
                 let object = {};
                 if (options.arrays || options.defaults) {
-                    object.chain = [];
                     object.parents = [];
+                    object.chain = [];
                 }
                 if (options.defaults) {
-                    object.timestamp = 0;
-                    object.body = null;
                     if ($util.Long) {
                         let long = new $util.Long(0, 0, false);
                         object.height = options.longs === String ? long.toString() : options.longs === Number ? long.toNumber() : long;
                     } else
                         object.height = options.longs === String ? "0" : 0;
+                    object.timestamp = 0;
+                    object.body = null;
                 }
-                if (message.chain && message.chain.length) {
-                    object.chain = [];
-                    for (let j = 0; j < message.chain.length; ++j)
-                        object.chain[j] = $root.Link.toObject(message.chain[j], options);
-                }
-                if (message.timestamp != null && message.hasOwnProperty("timestamp"))
-                    object.timestamp = options.json && !isFinite(message.timestamp) ? String(message.timestamp) : message.timestamp;
-                if (message.body != null && message.hasOwnProperty("body"))
-                    object.body = $root.ChannelMessage.Body.toObject(message.body, options);
                 if (message.parents && message.parents.length) {
                     object.parents = [];
                     for (let j = 0; j < message.parents.length; ++j)
@@ -2959,6 +2950,15 @@ export const ChannelMessage = $root.ChannelMessage = (() => {
                         object.height = options.longs === String ? String(message.height) : message.height;
                     else
                         object.height = options.longs === String ? $util.Long.prototype.toString.call(message.height) : options.longs === Number ? new $util.LongBits(message.height.low >>> 0, message.height.high >>> 0).toNumber() : message.height;
+                if (message.chain && message.chain.length) {
+                    object.chain = [];
+                    for (let j = 0; j < message.chain.length; ++j)
+                        object.chain[j] = $root.Link.toObject(message.chain[j], options);
+                }
+                if (message.timestamp != null && message.hasOwnProperty("timestamp"))
+                    object.timestamp = options.json && !isFinite(message.timestamp) ? String(message.timestamp) : message.timestamp;
+                if (message.body != null && message.hasOwnProperty("body"))
+                    object.body = $root.ChannelMessage.Body.toObject(message.body, options);
                 return object;
             };
 

--- a/lib/messages.js
+++ b/lib/messages.js
@@ -4672,8 +4672,8 @@ export const SyncResponse = $root.SyncResponse = (() => {
          * Properties of a Content.
          * @memberof SyncResponse
          * @interface IContent
-         * @property {IQueryResponse|null} [query] Content query
-         * @property {IBulkResponse|null} [bulk] Content bulk
+         * @property {IQueryResponse|null} [queryResponse] Content queryResponse
+         * @property {IBulkResponse|null} [bulkResponse] Content bulkResponse
          */
 
         /**
@@ -4692,32 +4692,32 @@ export const SyncResponse = $root.SyncResponse = (() => {
         }
 
         /**
-         * Content query.
-         * @member {IQueryResponse|null|undefined} query
+         * Content queryResponse.
+         * @member {IQueryResponse|null|undefined} queryResponse
          * @memberof SyncResponse.Content
          * @instance
          */
-        Content.prototype.query = null;
+        Content.prototype.queryResponse = null;
 
         /**
-         * Content bulk.
-         * @member {IBulkResponse|null|undefined} bulk
+         * Content bulkResponse.
+         * @member {IBulkResponse|null|undefined} bulkResponse
          * @memberof SyncResponse.Content
          * @instance
          */
-        Content.prototype.bulk = null;
+        Content.prototype.bulkResponse = null;
 
         // OneOf field names bound to virtual getters and setters
         let $oneOfFields;
 
         /**
          * Content content.
-         * @member {"query"|"bulk"|undefined} content
+         * @member {"queryResponse"|"bulkResponse"|undefined} content
          * @memberof SyncResponse.Content
          * @instance
          */
         Object.defineProperty(Content.prototype, "content", {
-            get: $util.oneOfGetter($oneOfFields = ["query", "bulk"]),
+            get: $util.oneOfGetter($oneOfFields = ["queryResponse", "bulkResponse"]),
             set: $util.oneOfSetter($oneOfFields)
         });
 
@@ -4745,10 +4745,10 @@ export const SyncResponse = $root.SyncResponse = (() => {
         Content.encode = function encode(message, writer) {
             if (!writer)
                 writer = $Writer.create();
-            if (message.query != null && message.hasOwnProperty("query"))
-                $root.QueryResponse.encode(message.query, writer.uint32(/* id 1, wireType 2 =*/10).fork()).ldelim();
-            if (message.bulk != null && message.hasOwnProperty("bulk"))
-                $root.BulkResponse.encode(message.bulk, writer.uint32(/* id 2, wireType 2 =*/18).fork()).ldelim();
+            if (message.queryResponse != null && message.hasOwnProperty("queryResponse"))
+                $root.QueryResponse.encode(message.queryResponse, writer.uint32(/* id 1, wireType 2 =*/10).fork()).ldelim();
+            if (message.bulkResponse != null && message.hasOwnProperty("bulkResponse"))
+                $root.BulkResponse.encode(message.bulkResponse, writer.uint32(/* id 2, wireType 2 =*/18).fork()).ldelim();
             return writer;
         };
 
@@ -4784,10 +4784,10 @@ export const SyncResponse = $root.SyncResponse = (() => {
                 let tag = reader.uint32();
                 switch (tag >>> 3) {
                 case 1:
-                    message.query = $root.QueryResponse.decode(reader, reader.uint32());
+                    message.queryResponse = $root.QueryResponse.decode(reader, reader.uint32());
                     break;
                 case 2:
-                    message.bulk = $root.BulkResponse.decode(reader, reader.uint32());
+                    message.bulkResponse = $root.BulkResponse.decode(reader, reader.uint32());
                     break;
                 default:
                     reader.skipType(tag & 7);
@@ -4825,22 +4825,22 @@ export const SyncResponse = $root.SyncResponse = (() => {
             if (typeof message !== "object" || message === null)
                 return "object expected";
             let properties = {};
-            if (message.query != null && message.hasOwnProperty("query")) {
+            if (message.queryResponse != null && message.hasOwnProperty("queryResponse")) {
                 properties.content = 1;
                 {
-                    let error = $root.QueryResponse.verify(message.query);
+                    let error = $root.QueryResponse.verify(message.queryResponse);
                     if (error)
-                        return "query." + error;
+                        return "queryResponse." + error;
                 }
             }
-            if (message.bulk != null && message.hasOwnProperty("bulk")) {
+            if (message.bulkResponse != null && message.hasOwnProperty("bulkResponse")) {
                 if (properties.content === 1)
                     return "content: multiple values";
                 properties.content = 1;
                 {
-                    let error = $root.BulkResponse.verify(message.bulk);
+                    let error = $root.BulkResponse.verify(message.bulkResponse);
                     if (error)
-                        return "bulk." + error;
+                        return "bulkResponse." + error;
                 }
             }
             return null;
@@ -4858,15 +4858,15 @@ export const SyncResponse = $root.SyncResponse = (() => {
             if (object instanceof $root.SyncResponse.Content)
                 return object;
             let message = new $root.SyncResponse.Content();
-            if (object.query != null) {
-                if (typeof object.query !== "object")
-                    throw TypeError(".SyncResponse.Content.query: object expected");
-                message.query = $root.QueryResponse.fromObject(object.query);
+            if (object.queryResponse != null) {
+                if (typeof object.queryResponse !== "object")
+                    throw TypeError(".SyncResponse.Content.queryResponse: object expected");
+                message.queryResponse = $root.QueryResponse.fromObject(object.queryResponse);
             }
-            if (object.bulk != null) {
-                if (typeof object.bulk !== "object")
-                    throw TypeError(".SyncResponse.Content.bulk: object expected");
-                message.bulk = $root.BulkResponse.fromObject(object.bulk);
+            if (object.bulkResponse != null) {
+                if (typeof object.bulkResponse !== "object")
+                    throw TypeError(".SyncResponse.Content.bulkResponse: object expected");
+                message.bulkResponse = $root.BulkResponse.fromObject(object.bulkResponse);
             }
             return message;
         };
@@ -4884,15 +4884,15 @@ export const SyncResponse = $root.SyncResponse = (() => {
             if (!options)
                 options = {};
             let object = {};
-            if (message.query != null && message.hasOwnProperty("query")) {
-                object.query = $root.QueryResponse.toObject(message.query, options);
+            if (message.queryResponse != null && message.hasOwnProperty("queryResponse")) {
+                object.queryResponse = $root.QueryResponse.toObject(message.queryResponse, options);
                 if (options.oneofs)
-                    object.content = "query";
+                    object.content = "queryResponse";
             }
-            if (message.bulk != null && message.hasOwnProperty("bulk")) {
-                object.bulk = $root.BulkResponse.toObject(message.bulk, options);
+            if (message.bulkResponse != null && message.hasOwnProperty("bulkResponse")) {
+                object.bulkResponse = $root.BulkResponse.toObject(message.bulkResponse, options);
                 if (options.oneofs)
-                    object.content = "bulk";
+                    object.content = "bulkResponse";
             }
             return object;
         };

--- a/lib/messages.js
+++ b/lib/messages.js
@@ -2616,8 +2616,6 @@ export const Query = $root.Query = (() => {
      * Properties of a Query.
      * @exports IQuery
      * @interface IQuery
-     * @property {Uint8Array|null} [channelId] Query channelId
-     * @property {number|null} [seq] Query seq
      * @property {number|Long|null} [height] Query height
      * @property {Uint8Array|null} [hash] Query hash
      * @property {boolean|null} [isBackward] Query isBackward
@@ -2638,22 +2636,6 @@ export const Query = $root.Query = (() => {
                 if (properties[keys[i]] != null)
                     this[keys[i]] = properties[keys[i]];
     }
-
-    /**
-     * Query channelId.
-     * @member {Uint8Array} channelId
-     * @memberof Query
-     * @instance
-     */
-    Query.prototype.channelId = $util.newBuffer([]);
-
-    /**
-     * Query seq.
-     * @member {number} seq
-     * @memberof Query
-     * @instance
-     */
-    Query.prototype.seq = 0;
 
     /**
      * Query height.
@@ -2725,18 +2707,14 @@ export const Query = $root.Query = (() => {
     Query.encode = function encode(message, writer) {
         if (!writer)
             writer = $Writer.create();
-        if (message.channelId != null && message.hasOwnProperty("channelId"))
-            writer.uint32(/* id 1, wireType 2 =*/10).bytes(message.channelId);
-        if (message.seq != null && message.hasOwnProperty("seq"))
-            writer.uint32(/* id 2, wireType 0 =*/16).uint32(message.seq);
         if (message.height != null && message.hasOwnProperty("height"))
-            writer.uint32(/* id 3, wireType 0 =*/24).int64(message.height);
+            writer.uint32(/* id 1, wireType 0 =*/8).int64(message.height);
         if (message.hash != null && message.hasOwnProperty("hash"))
-            writer.uint32(/* id 4, wireType 2 =*/34).bytes(message.hash);
+            writer.uint32(/* id 2, wireType 2 =*/18).bytes(message.hash);
         if (message.isBackward != null && message.hasOwnProperty("isBackward"))
-            writer.uint32(/* id 5, wireType 0 =*/40).bool(message.isBackward);
+            writer.uint32(/* id 3, wireType 0 =*/24).bool(message.isBackward);
         if (message.limit != null && message.hasOwnProperty("limit"))
-            writer.uint32(/* id 6, wireType 0 =*/48).uint32(message.limit);
+            writer.uint32(/* id 4, wireType 0 =*/32).uint32(message.limit);
         return writer;
     };
 
@@ -2772,21 +2750,15 @@ export const Query = $root.Query = (() => {
             let tag = reader.uint32();
             switch (tag >>> 3) {
             case 1:
-                message.channelId = reader.bytes();
-                break;
-            case 2:
-                message.seq = reader.uint32();
-                break;
-            case 3:
                 message.height = reader.int64();
                 break;
-            case 4:
+            case 2:
                 message.hash = reader.bytes();
                 break;
-            case 5:
+            case 3:
                 message.isBackward = reader.bool();
                 break;
-            case 6:
+            case 4:
                 message.limit = reader.uint32();
                 break;
             default:
@@ -2825,12 +2797,6 @@ export const Query = $root.Query = (() => {
         if (typeof message !== "object" || message === null)
             return "object expected";
         let properties = {};
-        if (message.channelId != null && message.hasOwnProperty("channelId"))
-            if (!(message.channelId && typeof message.channelId.length === "number" || $util.isString(message.channelId)))
-                return "channelId: buffer expected";
-        if (message.seq != null && message.hasOwnProperty("seq"))
-            if (!$util.isInteger(message.seq))
-                return "seq: integer expected";
         if (message.height != null && message.hasOwnProperty("height")) {
             properties.cursor = 1;
             if (!$util.isInteger(message.height) && !(message.height && $util.isInteger(message.height.low) && $util.isInteger(message.height.high)))
@@ -2864,13 +2830,6 @@ export const Query = $root.Query = (() => {
         if (object instanceof $root.Query)
             return object;
         let message = new $root.Query();
-        if (object.channelId != null)
-            if (typeof object.channelId === "string")
-                $util.base64.decode(object.channelId, message.channelId = $util.newBuffer($util.base64.length(object.channelId)), 0);
-            else if (object.channelId.length)
-                message.channelId = object.channelId;
-        if (object.seq != null)
-            message.seq = object.seq >>> 0;
         if (object.height != null)
             if ($util.Long)
                 (message.height = $util.Long.fromValue(object.height)).unsigned = false;
@@ -2906,21 +2865,9 @@ export const Query = $root.Query = (() => {
             options = {};
         let object = {};
         if (options.defaults) {
-            if (options.bytes === String)
-                object.channelId = "";
-            else {
-                object.channelId = [];
-                if (options.bytes !== Array)
-                    object.channelId = $util.newBuffer(object.channelId);
-            }
-            object.seq = 0;
             object.isBackward = false;
             object.limit = 0;
         }
-        if (message.channelId != null && message.hasOwnProperty("channelId"))
-            object.channelId = options.bytes === String ? $util.base64.encode(message.channelId, 0, message.channelId.length) : options.bytes === Array ? Array.prototype.slice.call(message.channelId) : message.channelId;
-        if (message.seq != null && message.hasOwnProperty("seq"))
-            object.seq = message.seq;
         if (message.height != null && message.hasOwnProperty("height")) {
             if (typeof message.height === "number")
                 object.height = options.longs === String ? String(message.height) : message.height;
@@ -2961,8 +2908,6 @@ export const QueryResponse = $root.QueryResponse = (() => {
      * Properties of a QueryResponse.
      * @exports IQueryResponse
      * @interface IQueryResponse
-     * @property {Uint8Array|null} [channelId] QueryResponse channelId
-     * @property {number|null} [seq] QueryResponse seq
      * @property {Array.<QueryResponse.IAbbreviated>|null} [abbreviatedMessages] QueryResponse abbreviatedMessages
      * @property {Uint8Array|null} [forwardHash] QueryResponse forwardHash
      * @property {Uint8Array|null} [backwardHash] QueryResponse backwardHash
@@ -2983,22 +2928,6 @@ export const QueryResponse = $root.QueryResponse = (() => {
                 if (properties[keys[i]] != null)
                     this[keys[i]] = properties[keys[i]];
     }
-
-    /**
-     * QueryResponse channelId.
-     * @member {Uint8Array} channelId
-     * @memberof QueryResponse
-     * @instance
-     */
-    QueryResponse.prototype.channelId = $util.newBuffer([]);
-
-    /**
-     * QueryResponse seq.
-     * @member {number} seq
-     * @memberof QueryResponse
-     * @instance
-     */
-    QueryResponse.prototype.seq = 0;
 
     /**
      * QueryResponse abbreviatedMessages.
@@ -3048,17 +2977,13 @@ export const QueryResponse = $root.QueryResponse = (() => {
     QueryResponse.encode = function encode(message, writer) {
         if (!writer)
             writer = $Writer.create();
-        if (message.channelId != null && message.hasOwnProperty("channelId"))
-            writer.uint32(/* id 1, wireType 2 =*/10).bytes(message.channelId);
-        if (message.seq != null && message.hasOwnProperty("seq"))
-            writer.uint32(/* id 2, wireType 0 =*/16).uint32(message.seq);
         if (message.abbreviatedMessages != null && message.abbreviatedMessages.length)
             for (let i = 0; i < message.abbreviatedMessages.length; ++i)
-                $root.QueryResponse.Abbreviated.encode(message.abbreviatedMessages[i], writer.uint32(/* id 3, wireType 2 =*/26).fork()).ldelim();
+                $root.QueryResponse.Abbreviated.encode(message.abbreviatedMessages[i], writer.uint32(/* id 1, wireType 2 =*/10).fork()).ldelim();
         if (message.forwardHash != null && message.hasOwnProperty("forwardHash"))
-            writer.uint32(/* id 4, wireType 2 =*/34).bytes(message.forwardHash);
+            writer.uint32(/* id 2, wireType 2 =*/18).bytes(message.forwardHash);
         if (message.backwardHash != null && message.hasOwnProperty("backwardHash"))
-            writer.uint32(/* id 5, wireType 2 =*/42).bytes(message.backwardHash);
+            writer.uint32(/* id 3, wireType 2 =*/26).bytes(message.backwardHash);
         return writer;
     };
 
@@ -3094,20 +3019,14 @@ export const QueryResponse = $root.QueryResponse = (() => {
             let tag = reader.uint32();
             switch (tag >>> 3) {
             case 1:
-                message.channelId = reader.bytes();
-                break;
-            case 2:
-                message.seq = reader.uint32();
-                break;
-            case 3:
                 if (!(message.abbreviatedMessages && message.abbreviatedMessages.length))
                     message.abbreviatedMessages = [];
                 message.abbreviatedMessages.push($root.QueryResponse.Abbreviated.decode(reader, reader.uint32()));
                 break;
-            case 4:
+            case 2:
                 message.forwardHash = reader.bytes();
                 break;
-            case 5:
+            case 3:
                 message.backwardHash = reader.bytes();
                 break;
             default:
@@ -3145,12 +3064,6 @@ export const QueryResponse = $root.QueryResponse = (() => {
     QueryResponse.verify = function verify(message) {
         if (typeof message !== "object" || message === null)
             return "object expected";
-        if (message.channelId != null && message.hasOwnProperty("channelId"))
-            if (!(message.channelId && typeof message.channelId.length === "number" || $util.isString(message.channelId)))
-                return "channelId: buffer expected";
-        if (message.seq != null && message.hasOwnProperty("seq"))
-            if (!$util.isInteger(message.seq))
-                return "seq: integer expected";
         if (message.abbreviatedMessages != null && message.hasOwnProperty("abbreviatedMessages")) {
             if (!Array.isArray(message.abbreviatedMessages))
                 return "abbreviatedMessages: array expected";
@@ -3181,13 +3094,6 @@ export const QueryResponse = $root.QueryResponse = (() => {
         if (object instanceof $root.QueryResponse)
             return object;
         let message = new $root.QueryResponse();
-        if (object.channelId != null)
-            if (typeof object.channelId === "string")
-                $util.base64.decode(object.channelId, message.channelId = $util.newBuffer($util.base64.length(object.channelId)), 0);
-            else if (object.channelId.length)
-                message.channelId = object.channelId;
-        if (object.seq != null)
-            message.seq = object.seq >>> 0;
         if (object.abbreviatedMessages) {
             if (!Array.isArray(object.abbreviatedMessages))
                 throw TypeError(".QueryResponse.abbreviatedMessages: array expected");
@@ -3228,14 +3134,6 @@ export const QueryResponse = $root.QueryResponse = (() => {
             object.abbreviatedMessages = [];
         if (options.defaults) {
             if (options.bytes === String)
-                object.channelId = "";
-            else {
-                object.channelId = [];
-                if (options.bytes !== Array)
-                    object.channelId = $util.newBuffer(object.channelId);
-            }
-            object.seq = 0;
-            if (options.bytes === String)
                 object.forwardHash = "";
             else {
                 object.forwardHash = [];
@@ -3250,10 +3148,6 @@ export const QueryResponse = $root.QueryResponse = (() => {
                     object.backwardHash = $util.newBuffer(object.backwardHash);
             }
         }
-        if (message.channelId != null && message.hasOwnProperty("channelId"))
-            object.channelId = options.bytes === String ? $util.base64.encode(message.channelId, 0, message.channelId.length) : options.bytes === Array ? Array.prototype.slice.call(message.channelId) : message.channelId;
-        if (message.seq != null && message.hasOwnProperty("seq"))
-            object.seq = message.seq;
         if (message.abbreviatedMessages && message.abbreviatedMessages.length) {
             object.abbreviatedMessages = [];
             for (let j = 0; j < message.abbreviatedMessages.length; ++j)
@@ -3524,8 +3418,6 @@ export const Bulk = $root.Bulk = (() => {
      * Properties of a Bulk.
      * @exports IBulk
      * @interface IBulk
-     * @property {Uint8Array|null} [channelId] Bulk channelId
-     * @property {number|null} [seq] Bulk seq
      * @property {Array.<Uint8Array>|null} [hashes] Bulk hashes
      */
 
@@ -3544,22 +3436,6 @@ export const Bulk = $root.Bulk = (() => {
                 if (properties[keys[i]] != null)
                     this[keys[i]] = properties[keys[i]];
     }
-
-    /**
-     * Bulk channelId.
-     * @member {Uint8Array} channelId
-     * @memberof Bulk
-     * @instance
-     */
-    Bulk.prototype.channelId = $util.newBuffer([]);
-
-    /**
-     * Bulk seq.
-     * @member {number} seq
-     * @memberof Bulk
-     * @instance
-     */
-    Bulk.prototype.seq = 0;
 
     /**
      * Bulk hashes.
@@ -3593,13 +3469,9 @@ export const Bulk = $root.Bulk = (() => {
     Bulk.encode = function encode(message, writer) {
         if (!writer)
             writer = $Writer.create();
-        if (message.channelId != null && message.hasOwnProperty("channelId"))
-            writer.uint32(/* id 1, wireType 2 =*/10).bytes(message.channelId);
-        if (message.seq != null && message.hasOwnProperty("seq"))
-            writer.uint32(/* id 2, wireType 0 =*/16).uint32(message.seq);
         if (message.hashes != null && message.hashes.length)
             for (let i = 0; i < message.hashes.length; ++i)
-                writer.uint32(/* id 3, wireType 2 =*/26).bytes(message.hashes[i]);
+                writer.uint32(/* id 1, wireType 2 =*/10).bytes(message.hashes[i]);
         return writer;
     };
 
@@ -3635,12 +3507,6 @@ export const Bulk = $root.Bulk = (() => {
             let tag = reader.uint32();
             switch (tag >>> 3) {
             case 1:
-                message.channelId = reader.bytes();
-                break;
-            case 2:
-                message.seq = reader.uint32();
-                break;
-            case 3:
                 if (!(message.hashes && message.hashes.length))
                     message.hashes = [];
                 message.hashes.push(reader.bytes());
@@ -3680,12 +3546,6 @@ export const Bulk = $root.Bulk = (() => {
     Bulk.verify = function verify(message) {
         if (typeof message !== "object" || message === null)
             return "object expected";
-        if (message.channelId != null && message.hasOwnProperty("channelId"))
-            if (!(message.channelId && typeof message.channelId.length === "number" || $util.isString(message.channelId)))
-                return "channelId: buffer expected";
-        if (message.seq != null && message.hasOwnProperty("seq"))
-            if (!$util.isInteger(message.seq))
-                return "seq: integer expected";
         if (message.hashes != null && message.hasOwnProperty("hashes")) {
             if (!Array.isArray(message.hashes))
                 return "hashes: array expected";
@@ -3708,13 +3568,6 @@ export const Bulk = $root.Bulk = (() => {
         if (object instanceof $root.Bulk)
             return object;
         let message = new $root.Bulk();
-        if (object.channelId != null)
-            if (typeof object.channelId === "string")
-                $util.base64.decode(object.channelId, message.channelId = $util.newBuffer($util.base64.length(object.channelId)), 0);
-            else if (object.channelId.length)
-                message.channelId = object.channelId;
-        if (object.seq != null)
-            message.seq = object.seq >>> 0;
         if (object.hashes) {
             if (!Array.isArray(object.hashes))
                 throw TypeError(".Bulk.hashes: array expected");
@@ -3743,20 +3596,6 @@ export const Bulk = $root.Bulk = (() => {
         let object = {};
         if (options.arrays || options.defaults)
             object.hashes = [];
-        if (options.defaults) {
-            if (options.bytes === String)
-                object.channelId = "";
-            else {
-                object.channelId = [];
-                if (options.bytes !== Array)
-                    object.channelId = $util.newBuffer(object.channelId);
-            }
-            object.seq = 0;
-        }
-        if (message.channelId != null && message.hasOwnProperty("channelId"))
-            object.channelId = options.bytes === String ? $util.base64.encode(message.channelId, 0, message.channelId.length) : options.bytes === Array ? Array.prototype.slice.call(message.channelId) : message.channelId;
-        if (message.seq != null && message.hasOwnProperty("seq"))
-            object.seq = message.seq;
         if (message.hashes && message.hashes.length) {
             object.hashes = [];
             for (let j = 0; j < message.hashes.length; ++j)
@@ -3785,8 +3624,6 @@ export const BulkResponse = $root.BulkResponse = (() => {
      * Properties of a BulkResponse.
      * @exports IBulkResponse
      * @interface IBulkResponse
-     * @property {Uint8Array|null} [channelId] BulkResponse channelId
-     * @property {number|null} [seq] BulkResponse seq
      * @property {Array.<IChannelMessage>|null} [messages] BulkResponse messages
      * @property {number|null} [forwardIndex] BulkResponse forwardIndex
      */
@@ -3806,22 +3643,6 @@ export const BulkResponse = $root.BulkResponse = (() => {
                 if (properties[keys[i]] != null)
                     this[keys[i]] = properties[keys[i]];
     }
-
-    /**
-     * BulkResponse channelId.
-     * @member {Uint8Array} channelId
-     * @memberof BulkResponse
-     * @instance
-     */
-    BulkResponse.prototype.channelId = $util.newBuffer([]);
-
-    /**
-     * BulkResponse seq.
-     * @member {number} seq
-     * @memberof BulkResponse
-     * @instance
-     */
-    BulkResponse.prototype.seq = 0;
 
     /**
      * BulkResponse messages.
@@ -3863,15 +3684,11 @@ export const BulkResponse = $root.BulkResponse = (() => {
     BulkResponse.encode = function encode(message, writer) {
         if (!writer)
             writer = $Writer.create();
-        if (message.channelId != null && message.hasOwnProperty("channelId"))
-            writer.uint32(/* id 1, wireType 2 =*/10).bytes(message.channelId);
-        if (message.seq != null && message.hasOwnProperty("seq"))
-            writer.uint32(/* id 2, wireType 0 =*/16).uint32(message.seq);
         if (message.messages != null && message.messages.length)
             for (let i = 0; i < message.messages.length; ++i)
-                $root.ChannelMessage.encode(message.messages[i], writer.uint32(/* id 3, wireType 2 =*/26).fork()).ldelim();
+                $root.ChannelMessage.encode(message.messages[i], writer.uint32(/* id 1, wireType 2 =*/10).fork()).ldelim();
         if (message.forwardIndex != null && message.hasOwnProperty("forwardIndex"))
-            writer.uint32(/* id 4, wireType 0 =*/32).uint32(message.forwardIndex);
+            writer.uint32(/* id 2, wireType 0 =*/16).uint32(message.forwardIndex);
         return writer;
     };
 
@@ -3907,17 +3724,11 @@ export const BulkResponse = $root.BulkResponse = (() => {
             let tag = reader.uint32();
             switch (tag >>> 3) {
             case 1:
-                message.channelId = reader.bytes();
-                break;
-            case 2:
-                message.seq = reader.uint32();
-                break;
-            case 3:
                 if (!(message.messages && message.messages.length))
                     message.messages = [];
                 message.messages.push($root.ChannelMessage.decode(reader, reader.uint32()));
                 break;
-            case 4:
+            case 2:
                 message.forwardIndex = reader.uint32();
                 break;
             default:
@@ -3955,12 +3766,6 @@ export const BulkResponse = $root.BulkResponse = (() => {
     BulkResponse.verify = function verify(message) {
         if (typeof message !== "object" || message === null)
             return "object expected";
-        if (message.channelId != null && message.hasOwnProperty("channelId"))
-            if (!(message.channelId && typeof message.channelId.length === "number" || $util.isString(message.channelId)))
-                return "channelId: buffer expected";
-        if (message.seq != null && message.hasOwnProperty("seq"))
-            if (!$util.isInteger(message.seq))
-                return "seq: integer expected";
         if (message.messages != null && message.hasOwnProperty("messages")) {
             if (!Array.isArray(message.messages))
                 return "messages: array expected";
@@ -3988,13 +3793,6 @@ export const BulkResponse = $root.BulkResponse = (() => {
         if (object instanceof $root.BulkResponse)
             return object;
         let message = new $root.BulkResponse();
-        if (object.channelId != null)
-            if (typeof object.channelId === "string")
-                $util.base64.decode(object.channelId, message.channelId = $util.newBuffer($util.base64.length(object.channelId)), 0);
-            else if (object.channelId.length)
-                message.channelId = object.channelId;
-        if (object.seq != null)
-            message.seq = object.seq >>> 0;
         if (object.messages) {
             if (!Array.isArray(object.messages))
                 throw TypeError(".BulkResponse.messages: array expected");
@@ -4025,21 +3823,8 @@ export const BulkResponse = $root.BulkResponse = (() => {
         let object = {};
         if (options.arrays || options.defaults)
             object.messages = [];
-        if (options.defaults) {
-            if (options.bytes === String)
-                object.channelId = "";
-            else {
-                object.channelId = [];
-                if (options.bytes !== Array)
-                    object.channelId = $util.newBuffer(object.channelId);
-            }
-            object.seq = 0;
+        if (options.defaults)
             object.forwardIndex = 0;
-        }
-        if (message.channelId != null && message.hasOwnProperty("channelId"))
-            object.channelId = options.bytes === String ? $util.base64.encode(message.channelId, 0, message.channelId.length) : options.bytes === Array ? Array.prototype.slice.call(message.channelId) : message.channelId;
-        if (message.seq != null && message.hasOwnProperty("seq"))
-            object.seq = message.seq;
         if (message.messages && message.messages.length) {
             object.messages = [];
             for (let j = 0; j < message.messages.length; ++j)
@@ -4251,6 +4036,600 @@ export const Error = $root.Error = (() => {
     return Error;
 })();
 
+export const ChannelPacket = $root.ChannelPacket = (() => {
+
+    /**
+     * Properties of a ChannelPacket.
+     * @exports IChannelPacket
+     * @interface IChannelPacket
+     * @property {Uint8Array|null} [channelId] ChannelPacket channelId
+     * @property {number|null} [seq] ChannelPacket seq
+     * @property {Uint8Array|null} [nonce] ChannelPacket nonce
+     * @property {Uint8Array|null} [box] ChannelPacket box
+     */
+
+    /**
+     * Constructs a new ChannelPacket.
+     * @exports ChannelPacket
+     * @classdesc Represents a ChannelPacket.
+     * @implements IChannelPacket
+     * @constructor
+     * @param {IChannelPacket=} [properties] Properties to set
+     */
+    function ChannelPacket(properties) {
+        if (properties)
+            for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                if (properties[keys[i]] != null)
+                    this[keys[i]] = properties[keys[i]];
+    }
+
+    /**
+     * ChannelPacket channelId.
+     * @member {Uint8Array} channelId
+     * @memberof ChannelPacket
+     * @instance
+     */
+    ChannelPacket.prototype.channelId = $util.newBuffer([]);
+
+    /**
+     * ChannelPacket seq.
+     * @member {number} seq
+     * @memberof ChannelPacket
+     * @instance
+     */
+    ChannelPacket.prototype.seq = 0;
+
+    /**
+     * ChannelPacket nonce.
+     * @member {Uint8Array} nonce
+     * @memberof ChannelPacket
+     * @instance
+     */
+    ChannelPacket.prototype.nonce = $util.newBuffer([]);
+
+    /**
+     * ChannelPacket box.
+     * @member {Uint8Array} box
+     * @memberof ChannelPacket
+     * @instance
+     */
+    ChannelPacket.prototype.box = $util.newBuffer([]);
+
+    /**
+     * Creates a new ChannelPacket instance using the specified properties.
+     * @function create
+     * @memberof ChannelPacket
+     * @static
+     * @param {IChannelPacket=} [properties] Properties to set
+     * @returns {ChannelPacket} ChannelPacket instance
+     */
+    ChannelPacket.create = function create(properties) {
+        return new ChannelPacket(properties);
+    };
+
+    /**
+     * Encodes the specified ChannelPacket message. Does not implicitly {@link ChannelPacket.verify|verify} messages.
+     * @function encode
+     * @memberof ChannelPacket
+     * @static
+     * @param {IChannelPacket} message ChannelPacket message or plain object to encode
+     * @param {$protobuf.Writer} [writer] Writer to encode to
+     * @returns {$protobuf.Writer} Writer
+     */
+    ChannelPacket.encode = function encode(message, writer) {
+        if (!writer)
+            writer = $Writer.create();
+        if (message.channelId != null && message.hasOwnProperty("channelId"))
+            writer.uint32(/* id 1, wireType 2 =*/10).bytes(message.channelId);
+        if (message.seq != null && message.hasOwnProperty("seq"))
+            writer.uint32(/* id 2, wireType 0 =*/16).uint32(message.seq);
+        if (message.nonce != null && message.hasOwnProperty("nonce"))
+            writer.uint32(/* id 3, wireType 2 =*/26).bytes(message.nonce);
+        if (message.box != null && message.hasOwnProperty("box"))
+            writer.uint32(/* id 4, wireType 2 =*/34).bytes(message.box);
+        return writer;
+    };
+
+    /**
+     * Encodes the specified ChannelPacket message, length delimited. Does not implicitly {@link ChannelPacket.verify|verify} messages.
+     * @function encodeDelimited
+     * @memberof ChannelPacket
+     * @static
+     * @param {IChannelPacket} message ChannelPacket message or plain object to encode
+     * @param {$protobuf.Writer} [writer] Writer to encode to
+     * @returns {$protobuf.Writer} Writer
+     */
+    ChannelPacket.encodeDelimited = function encodeDelimited(message, writer) {
+        return this.encode(message, writer).ldelim();
+    };
+
+    /**
+     * Decodes a ChannelPacket message from the specified reader or buffer.
+     * @function decode
+     * @memberof ChannelPacket
+     * @static
+     * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+     * @param {number} [length] Message length if known beforehand
+     * @returns {ChannelPacket} ChannelPacket
+     * @throws {Error} If the payload is not a reader or valid buffer
+     * @throws {$protobuf.util.ProtocolError} If required fields are missing
+     */
+    ChannelPacket.decode = function decode(reader, length) {
+        if (!(reader instanceof $Reader))
+            reader = $Reader.create(reader);
+        let end = length === undefined ? reader.len : reader.pos + length, message = new $root.ChannelPacket();
+        while (reader.pos < end) {
+            let tag = reader.uint32();
+            switch (tag >>> 3) {
+            case 1:
+                message.channelId = reader.bytes();
+                break;
+            case 2:
+                message.seq = reader.uint32();
+                break;
+            case 3:
+                message.nonce = reader.bytes();
+                break;
+            case 4:
+                message.box = reader.bytes();
+                break;
+            default:
+                reader.skipType(tag & 7);
+                break;
+            }
+        }
+        return message;
+    };
+
+    /**
+     * Decodes a ChannelPacket message from the specified reader or buffer, length delimited.
+     * @function decodeDelimited
+     * @memberof ChannelPacket
+     * @static
+     * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+     * @returns {ChannelPacket} ChannelPacket
+     * @throws {Error} If the payload is not a reader or valid buffer
+     * @throws {$protobuf.util.ProtocolError} If required fields are missing
+     */
+    ChannelPacket.decodeDelimited = function decodeDelimited(reader) {
+        if (!(reader instanceof $Reader))
+            reader = new $Reader(reader);
+        return this.decode(reader, reader.uint32());
+    };
+
+    /**
+     * Verifies a ChannelPacket message.
+     * @function verify
+     * @memberof ChannelPacket
+     * @static
+     * @param {Object.<string,*>} message Plain object to verify
+     * @returns {string|null} `null` if valid, otherwise the reason why it is not
+     */
+    ChannelPacket.verify = function verify(message) {
+        if (typeof message !== "object" || message === null)
+            return "object expected";
+        if (message.channelId != null && message.hasOwnProperty("channelId"))
+            if (!(message.channelId && typeof message.channelId.length === "number" || $util.isString(message.channelId)))
+                return "channelId: buffer expected";
+        if (message.seq != null && message.hasOwnProperty("seq"))
+            if (!$util.isInteger(message.seq))
+                return "seq: integer expected";
+        if (message.nonce != null && message.hasOwnProperty("nonce"))
+            if (!(message.nonce && typeof message.nonce.length === "number" || $util.isString(message.nonce)))
+                return "nonce: buffer expected";
+        if (message.box != null && message.hasOwnProperty("box"))
+            if (!(message.box && typeof message.box.length === "number" || $util.isString(message.box)))
+                return "box: buffer expected";
+        return null;
+    };
+
+    /**
+     * Creates a ChannelPacket message from a plain object. Also converts values to their respective internal types.
+     * @function fromObject
+     * @memberof ChannelPacket
+     * @static
+     * @param {Object.<string,*>} object Plain object
+     * @returns {ChannelPacket} ChannelPacket
+     */
+    ChannelPacket.fromObject = function fromObject(object) {
+        if (object instanceof $root.ChannelPacket)
+            return object;
+        let message = new $root.ChannelPacket();
+        if (object.channelId != null)
+            if (typeof object.channelId === "string")
+                $util.base64.decode(object.channelId, message.channelId = $util.newBuffer($util.base64.length(object.channelId)), 0);
+            else if (object.channelId.length)
+                message.channelId = object.channelId;
+        if (object.seq != null)
+            message.seq = object.seq >>> 0;
+        if (object.nonce != null)
+            if (typeof object.nonce === "string")
+                $util.base64.decode(object.nonce, message.nonce = $util.newBuffer($util.base64.length(object.nonce)), 0);
+            else if (object.nonce.length)
+                message.nonce = object.nonce;
+        if (object.box != null)
+            if (typeof object.box === "string")
+                $util.base64.decode(object.box, message.box = $util.newBuffer($util.base64.length(object.box)), 0);
+            else if (object.box.length)
+                message.box = object.box;
+        return message;
+    };
+
+    /**
+     * Creates a plain object from a ChannelPacket message. Also converts values to other types if specified.
+     * @function toObject
+     * @memberof ChannelPacket
+     * @static
+     * @param {ChannelPacket} message ChannelPacket
+     * @param {$protobuf.IConversionOptions} [options] Conversion options
+     * @returns {Object.<string,*>} Plain object
+     */
+    ChannelPacket.toObject = function toObject(message, options) {
+        if (!options)
+            options = {};
+        let object = {};
+        if (options.defaults) {
+            if (options.bytes === String)
+                object.channelId = "";
+            else {
+                object.channelId = [];
+                if (options.bytes !== Array)
+                    object.channelId = $util.newBuffer(object.channelId);
+            }
+            object.seq = 0;
+            if (options.bytes === String)
+                object.nonce = "";
+            else {
+                object.nonce = [];
+                if (options.bytes !== Array)
+                    object.nonce = $util.newBuffer(object.nonce);
+            }
+            if (options.bytes === String)
+                object.box = "";
+            else {
+                object.box = [];
+                if (options.bytes !== Array)
+                    object.box = $util.newBuffer(object.box);
+            }
+        }
+        if (message.channelId != null && message.hasOwnProperty("channelId"))
+            object.channelId = options.bytes === String ? $util.base64.encode(message.channelId, 0, message.channelId.length) : options.bytes === Array ? Array.prototype.slice.call(message.channelId) : message.channelId;
+        if (message.seq != null && message.hasOwnProperty("seq"))
+            object.seq = message.seq;
+        if (message.nonce != null && message.hasOwnProperty("nonce"))
+            object.nonce = options.bytes === String ? $util.base64.encode(message.nonce, 0, message.nonce.length) : options.bytes === Array ? Array.prototype.slice.call(message.nonce) : message.nonce;
+        if (message.box != null && message.hasOwnProperty("box"))
+            object.box = options.bytes === String ? $util.base64.encode(message.box, 0, message.box.length) : options.bytes === Array ? Array.prototype.slice.call(message.box) : message.box;
+        return object;
+    };
+
+    /**
+     * Converts this ChannelPacket to JSON.
+     * @function toJSON
+     * @memberof ChannelPacket
+     * @instance
+     * @returns {Object.<string,*>} JSON object
+     */
+    ChannelPacket.prototype.toJSON = function toJSON() {
+        return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+    };
+
+    ChannelPacket.Content = (function() {
+
+        /**
+         * Properties of a Content.
+         * @memberof ChannelPacket
+         * @interface IContent
+         * @property {IQuery|null} [query] Content query
+         * @property {IQueryResponse|null} [queryResponse] Content queryResponse
+         * @property {IBulk|null} [bulk] Content bulk
+         * @property {IBulkResponse|null} [bulkResponse] Content bulkResponse
+         */
+
+        /**
+         * Constructs a new Content.
+         * @memberof ChannelPacket
+         * @classdesc Represents a Content.
+         * @implements IContent
+         * @constructor
+         * @param {ChannelPacket.IContent=} [properties] Properties to set
+         */
+        function Content(properties) {
+            if (properties)
+                for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                    if (properties[keys[i]] != null)
+                        this[keys[i]] = properties[keys[i]];
+        }
+
+        /**
+         * Content query.
+         * @member {IQuery|null|undefined} query
+         * @memberof ChannelPacket.Content
+         * @instance
+         */
+        Content.prototype.query = null;
+
+        /**
+         * Content queryResponse.
+         * @member {IQueryResponse|null|undefined} queryResponse
+         * @memberof ChannelPacket.Content
+         * @instance
+         */
+        Content.prototype.queryResponse = null;
+
+        /**
+         * Content bulk.
+         * @member {IBulk|null|undefined} bulk
+         * @memberof ChannelPacket.Content
+         * @instance
+         */
+        Content.prototype.bulk = null;
+
+        /**
+         * Content bulkResponse.
+         * @member {IBulkResponse|null|undefined} bulkResponse
+         * @memberof ChannelPacket.Content
+         * @instance
+         */
+        Content.prototype.bulkResponse = null;
+
+        // OneOf field names bound to virtual getters and setters
+        let $oneOfFields;
+
+        /**
+         * Content content.
+         * @member {"query"|"queryResponse"|"bulk"|"bulkResponse"|undefined} content
+         * @memberof ChannelPacket.Content
+         * @instance
+         */
+        Object.defineProperty(Content.prototype, "content", {
+            get: $util.oneOfGetter($oneOfFields = ["query", "queryResponse", "bulk", "bulkResponse"]),
+            set: $util.oneOfSetter($oneOfFields)
+        });
+
+        /**
+         * Creates a new Content instance using the specified properties.
+         * @function create
+         * @memberof ChannelPacket.Content
+         * @static
+         * @param {ChannelPacket.IContent=} [properties] Properties to set
+         * @returns {ChannelPacket.Content} Content instance
+         */
+        Content.create = function create(properties) {
+            return new Content(properties);
+        };
+
+        /**
+         * Encodes the specified Content message. Does not implicitly {@link ChannelPacket.Content.verify|verify} messages.
+         * @function encode
+         * @memberof ChannelPacket.Content
+         * @static
+         * @param {ChannelPacket.IContent} message Content message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        Content.encode = function encode(message, writer) {
+            if (!writer)
+                writer = $Writer.create();
+            if (message.query != null && message.hasOwnProperty("query"))
+                $root.Query.encode(message.query, writer.uint32(/* id 1, wireType 2 =*/10).fork()).ldelim();
+            if (message.queryResponse != null && message.hasOwnProperty("queryResponse"))
+                $root.QueryResponse.encode(message.queryResponse, writer.uint32(/* id 2, wireType 2 =*/18).fork()).ldelim();
+            if (message.bulk != null && message.hasOwnProperty("bulk"))
+                $root.Bulk.encode(message.bulk, writer.uint32(/* id 3, wireType 2 =*/26).fork()).ldelim();
+            if (message.bulkResponse != null && message.hasOwnProperty("bulkResponse"))
+                $root.BulkResponse.encode(message.bulkResponse, writer.uint32(/* id 4, wireType 2 =*/34).fork()).ldelim();
+            return writer;
+        };
+
+        /**
+         * Encodes the specified Content message, length delimited. Does not implicitly {@link ChannelPacket.Content.verify|verify} messages.
+         * @function encodeDelimited
+         * @memberof ChannelPacket.Content
+         * @static
+         * @param {ChannelPacket.IContent} message Content message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        Content.encodeDelimited = function encodeDelimited(message, writer) {
+            return this.encode(message, writer).ldelim();
+        };
+
+        /**
+         * Decodes a Content message from the specified reader or buffer.
+         * @function decode
+         * @memberof ChannelPacket.Content
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @param {number} [length] Message length if known beforehand
+         * @returns {ChannelPacket.Content} Content
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        Content.decode = function decode(reader, length) {
+            if (!(reader instanceof $Reader))
+                reader = $Reader.create(reader);
+            let end = length === undefined ? reader.len : reader.pos + length, message = new $root.ChannelPacket.Content();
+            while (reader.pos < end) {
+                let tag = reader.uint32();
+                switch (tag >>> 3) {
+                case 1:
+                    message.query = $root.Query.decode(reader, reader.uint32());
+                    break;
+                case 2:
+                    message.queryResponse = $root.QueryResponse.decode(reader, reader.uint32());
+                    break;
+                case 3:
+                    message.bulk = $root.Bulk.decode(reader, reader.uint32());
+                    break;
+                case 4:
+                    message.bulkResponse = $root.BulkResponse.decode(reader, reader.uint32());
+                    break;
+                default:
+                    reader.skipType(tag & 7);
+                    break;
+                }
+            }
+            return message;
+        };
+
+        /**
+         * Decodes a Content message from the specified reader or buffer, length delimited.
+         * @function decodeDelimited
+         * @memberof ChannelPacket.Content
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @returns {ChannelPacket.Content} Content
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        Content.decodeDelimited = function decodeDelimited(reader) {
+            if (!(reader instanceof $Reader))
+                reader = new $Reader(reader);
+            return this.decode(reader, reader.uint32());
+        };
+
+        /**
+         * Verifies a Content message.
+         * @function verify
+         * @memberof ChannelPacket.Content
+         * @static
+         * @param {Object.<string,*>} message Plain object to verify
+         * @returns {string|null} `null` if valid, otherwise the reason why it is not
+         */
+        Content.verify = function verify(message) {
+            if (typeof message !== "object" || message === null)
+                return "object expected";
+            let properties = {};
+            if (message.query != null && message.hasOwnProperty("query")) {
+                properties.content = 1;
+                {
+                    let error = $root.Query.verify(message.query);
+                    if (error)
+                        return "query." + error;
+                }
+            }
+            if (message.queryResponse != null && message.hasOwnProperty("queryResponse")) {
+                if (properties.content === 1)
+                    return "content: multiple values";
+                properties.content = 1;
+                {
+                    let error = $root.QueryResponse.verify(message.queryResponse);
+                    if (error)
+                        return "queryResponse." + error;
+                }
+            }
+            if (message.bulk != null && message.hasOwnProperty("bulk")) {
+                if (properties.content === 1)
+                    return "content: multiple values";
+                properties.content = 1;
+                {
+                    let error = $root.Bulk.verify(message.bulk);
+                    if (error)
+                        return "bulk." + error;
+                }
+            }
+            if (message.bulkResponse != null && message.hasOwnProperty("bulkResponse")) {
+                if (properties.content === 1)
+                    return "content: multiple values";
+                properties.content = 1;
+                {
+                    let error = $root.BulkResponse.verify(message.bulkResponse);
+                    if (error)
+                        return "bulkResponse." + error;
+                }
+            }
+            return null;
+        };
+
+        /**
+         * Creates a Content message from a plain object. Also converts values to their respective internal types.
+         * @function fromObject
+         * @memberof ChannelPacket.Content
+         * @static
+         * @param {Object.<string,*>} object Plain object
+         * @returns {ChannelPacket.Content} Content
+         */
+        Content.fromObject = function fromObject(object) {
+            if (object instanceof $root.ChannelPacket.Content)
+                return object;
+            let message = new $root.ChannelPacket.Content();
+            if (object.query != null) {
+                if (typeof object.query !== "object")
+                    throw TypeError(".ChannelPacket.Content.query: object expected");
+                message.query = $root.Query.fromObject(object.query);
+            }
+            if (object.queryResponse != null) {
+                if (typeof object.queryResponse !== "object")
+                    throw TypeError(".ChannelPacket.Content.queryResponse: object expected");
+                message.queryResponse = $root.QueryResponse.fromObject(object.queryResponse);
+            }
+            if (object.bulk != null) {
+                if (typeof object.bulk !== "object")
+                    throw TypeError(".ChannelPacket.Content.bulk: object expected");
+                message.bulk = $root.Bulk.fromObject(object.bulk);
+            }
+            if (object.bulkResponse != null) {
+                if (typeof object.bulkResponse !== "object")
+                    throw TypeError(".ChannelPacket.Content.bulkResponse: object expected");
+                message.bulkResponse = $root.BulkResponse.fromObject(object.bulkResponse);
+            }
+            return message;
+        };
+
+        /**
+         * Creates a plain object from a Content message. Also converts values to other types if specified.
+         * @function toObject
+         * @memberof ChannelPacket.Content
+         * @static
+         * @param {ChannelPacket.Content} message Content
+         * @param {$protobuf.IConversionOptions} [options] Conversion options
+         * @returns {Object.<string,*>} Plain object
+         */
+        Content.toObject = function toObject(message, options) {
+            if (!options)
+                options = {};
+            let object = {};
+            if (message.query != null && message.hasOwnProperty("query")) {
+                object.query = $root.Query.toObject(message.query, options);
+                if (options.oneofs)
+                    object.content = "query";
+            }
+            if (message.queryResponse != null && message.hasOwnProperty("queryResponse")) {
+                object.queryResponse = $root.QueryResponse.toObject(message.queryResponse, options);
+                if (options.oneofs)
+                    object.content = "queryResponse";
+            }
+            if (message.bulk != null && message.hasOwnProperty("bulk")) {
+                object.bulk = $root.Bulk.toObject(message.bulk, options);
+                if (options.oneofs)
+                    object.content = "bulk";
+            }
+            if (message.bulkResponse != null && message.hasOwnProperty("bulkResponse")) {
+                object.bulkResponse = $root.BulkResponse.toObject(message.bulkResponse, options);
+                if (options.oneofs)
+                    object.content = "bulkResponse";
+            }
+            return object;
+        };
+
+        /**
+         * Converts this Content to JSON.
+         * @function toJSON
+         * @memberof ChannelPacket.Content
+         * @instance
+         * @returns {Object.<string,*>} JSON object
+         */
+        Content.prototype.toJSON = function toJSON() {
+            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+        };
+
+        return Content;
+    })();
+
+    return ChannelPacket;
+})();
+
 export const Notification = $root.Notification = (() => {
 
     /**
@@ -4455,10 +4834,7 @@ export const Packet = $root.Packet = (() => {
      * @interface IPacket
      * @property {IError|null} [error] Packet error
      * @property {IEncryptedInvite|null} [invite] Packet invite
-     * @property {IQuery|null} [query] Packet query
-     * @property {IQueryResponse|null} [queryResponse] Packet queryResponse
-     * @property {IBulk|null} [bulk] Packet bulk
-     * @property {IBulkResponse|null} [bulkResponse] Packet bulkResponse
+     * @property {IChannelPacket|null} [channelPacket] Packet channelPacket
      * @property {INotification|null} [notification] Packet notification
      */
 
@@ -4494,36 +4870,12 @@ export const Packet = $root.Packet = (() => {
     Packet.prototype.invite = null;
 
     /**
-     * Packet query.
-     * @member {IQuery|null|undefined} query
+     * Packet channelPacket.
+     * @member {IChannelPacket|null|undefined} channelPacket
      * @memberof Packet
      * @instance
      */
-    Packet.prototype.query = null;
-
-    /**
-     * Packet queryResponse.
-     * @member {IQueryResponse|null|undefined} queryResponse
-     * @memberof Packet
-     * @instance
-     */
-    Packet.prototype.queryResponse = null;
-
-    /**
-     * Packet bulk.
-     * @member {IBulk|null|undefined} bulk
-     * @memberof Packet
-     * @instance
-     */
-    Packet.prototype.bulk = null;
-
-    /**
-     * Packet bulkResponse.
-     * @member {IBulkResponse|null|undefined} bulkResponse
-     * @memberof Packet
-     * @instance
-     */
-    Packet.prototype.bulkResponse = null;
+    Packet.prototype.channelPacket = null;
 
     /**
      * Packet notification.
@@ -4538,12 +4890,12 @@ export const Packet = $root.Packet = (() => {
 
     /**
      * Packet content.
-     * @member {"error"|"invite"|"query"|"queryResponse"|"bulk"|"bulkResponse"|"notification"|undefined} content
+     * @member {"error"|"invite"|"channelPacket"|"notification"|undefined} content
      * @memberof Packet
      * @instance
      */
     Object.defineProperty(Packet.prototype, "content", {
-        get: $util.oneOfGetter($oneOfFields = ["error", "invite", "query", "queryResponse", "bulk", "bulkResponse", "notification"]),
+        get: $util.oneOfGetter($oneOfFields = ["error", "invite", "channelPacket", "notification"]),
         set: $util.oneOfSetter($oneOfFields)
     });
 
@@ -4575,16 +4927,10 @@ export const Packet = $root.Packet = (() => {
             $root.Error.encode(message.error, writer.uint32(/* id 1, wireType 2 =*/10).fork()).ldelim();
         if (message.invite != null && message.hasOwnProperty("invite"))
             $root.EncryptedInvite.encode(message.invite, writer.uint32(/* id 2, wireType 2 =*/18).fork()).ldelim();
-        if (message.query != null && message.hasOwnProperty("query"))
-            $root.Query.encode(message.query, writer.uint32(/* id 3, wireType 2 =*/26).fork()).ldelim();
-        if (message.queryResponse != null && message.hasOwnProperty("queryResponse"))
-            $root.QueryResponse.encode(message.queryResponse, writer.uint32(/* id 4, wireType 2 =*/34).fork()).ldelim();
-        if (message.bulk != null && message.hasOwnProperty("bulk"))
-            $root.Bulk.encode(message.bulk, writer.uint32(/* id 5, wireType 2 =*/42).fork()).ldelim();
-        if (message.bulkResponse != null && message.hasOwnProperty("bulkResponse"))
-            $root.BulkResponse.encode(message.bulkResponse, writer.uint32(/* id 6, wireType 2 =*/50).fork()).ldelim();
+        if (message.channelPacket != null && message.hasOwnProperty("channelPacket"))
+            $root.ChannelPacket.encode(message.channelPacket, writer.uint32(/* id 3, wireType 2 =*/26).fork()).ldelim();
         if (message.notification != null && message.hasOwnProperty("notification"))
-            $root.Notification.encode(message.notification, writer.uint32(/* id 7, wireType 2 =*/58).fork()).ldelim();
+            $root.Notification.encode(message.notification, writer.uint32(/* id 4, wireType 2 =*/34).fork()).ldelim();
         return writer;
     };
 
@@ -4626,18 +4972,9 @@ export const Packet = $root.Packet = (() => {
                 message.invite = $root.EncryptedInvite.decode(reader, reader.uint32());
                 break;
             case 3:
-                message.query = $root.Query.decode(reader, reader.uint32());
+                message.channelPacket = $root.ChannelPacket.decode(reader, reader.uint32());
                 break;
             case 4:
-                message.queryResponse = $root.QueryResponse.decode(reader, reader.uint32());
-                break;
-            case 5:
-                message.bulk = $root.Bulk.decode(reader, reader.uint32());
-                break;
-            case 6:
-                message.bulkResponse = $root.BulkResponse.decode(reader, reader.uint32());
-                break;
-            case 7:
                 message.notification = $root.Notification.decode(reader, reader.uint32());
                 break;
             default:
@@ -4694,44 +5031,14 @@ export const Packet = $root.Packet = (() => {
                     return "invite." + error;
             }
         }
-        if (message.query != null && message.hasOwnProperty("query")) {
+        if (message.channelPacket != null && message.hasOwnProperty("channelPacket")) {
             if (properties.content === 1)
                 return "content: multiple values";
             properties.content = 1;
             {
-                let error = $root.Query.verify(message.query);
+                let error = $root.ChannelPacket.verify(message.channelPacket);
                 if (error)
-                    return "query." + error;
-            }
-        }
-        if (message.queryResponse != null && message.hasOwnProperty("queryResponse")) {
-            if (properties.content === 1)
-                return "content: multiple values";
-            properties.content = 1;
-            {
-                let error = $root.QueryResponse.verify(message.queryResponse);
-                if (error)
-                    return "queryResponse." + error;
-            }
-        }
-        if (message.bulk != null && message.hasOwnProperty("bulk")) {
-            if (properties.content === 1)
-                return "content: multiple values";
-            properties.content = 1;
-            {
-                let error = $root.Bulk.verify(message.bulk);
-                if (error)
-                    return "bulk." + error;
-            }
-        }
-        if (message.bulkResponse != null && message.hasOwnProperty("bulkResponse")) {
-            if (properties.content === 1)
-                return "content: multiple values";
-            properties.content = 1;
-            {
-                let error = $root.BulkResponse.verify(message.bulkResponse);
-                if (error)
-                    return "bulkResponse." + error;
+                    return "channelPacket." + error;
             }
         }
         if (message.notification != null && message.hasOwnProperty("notification")) {
@@ -4769,25 +5076,10 @@ export const Packet = $root.Packet = (() => {
                 throw TypeError(".Packet.invite: object expected");
             message.invite = $root.EncryptedInvite.fromObject(object.invite);
         }
-        if (object.query != null) {
-            if (typeof object.query !== "object")
-                throw TypeError(".Packet.query: object expected");
-            message.query = $root.Query.fromObject(object.query);
-        }
-        if (object.queryResponse != null) {
-            if (typeof object.queryResponse !== "object")
-                throw TypeError(".Packet.queryResponse: object expected");
-            message.queryResponse = $root.QueryResponse.fromObject(object.queryResponse);
-        }
-        if (object.bulk != null) {
-            if (typeof object.bulk !== "object")
-                throw TypeError(".Packet.bulk: object expected");
-            message.bulk = $root.Bulk.fromObject(object.bulk);
-        }
-        if (object.bulkResponse != null) {
-            if (typeof object.bulkResponse !== "object")
-                throw TypeError(".Packet.bulkResponse: object expected");
-            message.bulkResponse = $root.BulkResponse.fromObject(object.bulkResponse);
+        if (object.channelPacket != null) {
+            if (typeof object.channelPacket !== "object")
+                throw TypeError(".Packet.channelPacket: object expected");
+            message.channelPacket = $root.ChannelPacket.fromObject(object.channelPacket);
         }
         if (object.notification != null) {
             if (typeof object.notification !== "object")
@@ -4820,25 +5112,10 @@ export const Packet = $root.Packet = (() => {
             if (options.oneofs)
                 object.content = "invite";
         }
-        if (message.query != null && message.hasOwnProperty("query")) {
-            object.query = $root.Query.toObject(message.query, options);
+        if (message.channelPacket != null && message.hasOwnProperty("channelPacket")) {
+            object.channelPacket = $root.ChannelPacket.toObject(message.channelPacket, options);
             if (options.oneofs)
-                object.content = "query";
-        }
-        if (message.queryResponse != null && message.hasOwnProperty("queryResponse")) {
-            object.queryResponse = $root.QueryResponse.toObject(message.queryResponse, options);
-            if (options.oneofs)
-                object.content = "queryResponse";
-        }
-        if (message.bulk != null && message.hasOwnProperty("bulk")) {
-            object.bulk = $root.Bulk.toObject(message.bulk, options);
-            if (options.oneofs)
-                object.content = "bulk";
-        }
-        if (message.bulkResponse != null && message.hasOwnProperty("bulkResponse")) {
-            object.bulkResponse = $root.BulkResponse.toObject(message.bulkResponse, options);
-            if (options.oneofs)
-                object.content = "bulkResponse";
+                object.content = "channelPacket";
         }
         if (message.notification != null && message.hasOwnProperty("notification")) {
             object.notification = $root.Notification.toObject(message.notification, options);

--- a/lib/messages.js
+++ b/lib/messages.js
@@ -1656,8 +1656,8 @@ export const ChannelMessage = $root.ChannelMessage = (() => {
      * Properties of a ChannelMessage.
      * @exports IChannelMessage
      * @interface IChannelMessage
-     * @property {Uint8Array|null} [nonce] ChannelMessage nonce
-     * @property {Uint8Array|null} [encryptedContent] ChannelMessage encryptedContent
+     * @property {ChannelMessage.ITBS|null} [tbs] ChannelMessage tbs
+     * @property {Uint8Array|null} [signature] ChannelMessage signature
      */
 
     /**
@@ -1676,20 +1676,20 @@ export const ChannelMessage = $root.ChannelMessage = (() => {
     }
 
     /**
-     * ChannelMessage nonce.
-     * @member {Uint8Array} nonce
+     * ChannelMessage tbs.
+     * @member {ChannelMessage.ITBS|null|undefined} tbs
      * @memberof ChannelMessage
      * @instance
      */
-    ChannelMessage.prototype.nonce = $util.newBuffer([]);
+    ChannelMessage.prototype.tbs = null;
 
     /**
-     * ChannelMessage encryptedContent.
-     * @member {Uint8Array} encryptedContent
+     * ChannelMessage signature.
+     * @member {Uint8Array} signature
      * @memberof ChannelMessage
      * @instance
      */
-    ChannelMessage.prototype.encryptedContent = $util.newBuffer([]);
+    ChannelMessage.prototype.signature = $util.newBuffer([]);
 
     /**
      * Creates a new ChannelMessage instance using the specified properties.
@@ -1715,10 +1715,10 @@ export const ChannelMessage = $root.ChannelMessage = (() => {
     ChannelMessage.encode = function encode(message, writer) {
         if (!writer)
             writer = $Writer.create();
-        if (message.nonce != null && message.hasOwnProperty("nonce"))
-            writer.uint32(/* id 1, wireType 2 =*/10).bytes(message.nonce);
-        if (message.encryptedContent != null && message.hasOwnProperty("encryptedContent"))
-            writer.uint32(/* id 2, wireType 2 =*/18).bytes(message.encryptedContent);
+        if (message.tbs != null && message.hasOwnProperty("tbs"))
+            $root.ChannelMessage.TBS.encode(message.tbs, writer.uint32(/* id 1, wireType 2 =*/10).fork()).ldelim();
+        if (message.signature != null && message.hasOwnProperty("signature"))
+            writer.uint32(/* id 2, wireType 2 =*/18).bytes(message.signature);
         return writer;
     };
 
@@ -1754,10 +1754,10 @@ export const ChannelMessage = $root.ChannelMessage = (() => {
             let tag = reader.uint32();
             switch (tag >>> 3) {
             case 1:
-                message.nonce = reader.bytes();
+                message.tbs = $root.ChannelMessage.TBS.decode(reader, reader.uint32());
                 break;
             case 2:
-                message.encryptedContent = reader.bytes();
+                message.signature = reader.bytes();
                 break;
             default:
                 reader.skipType(tag & 7);
@@ -1794,12 +1794,14 @@ export const ChannelMessage = $root.ChannelMessage = (() => {
     ChannelMessage.verify = function verify(message) {
         if (typeof message !== "object" || message === null)
             return "object expected";
-        if (message.nonce != null && message.hasOwnProperty("nonce"))
-            if (!(message.nonce && typeof message.nonce.length === "number" || $util.isString(message.nonce)))
-                return "nonce: buffer expected";
-        if (message.encryptedContent != null && message.hasOwnProperty("encryptedContent"))
-            if (!(message.encryptedContent && typeof message.encryptedContent.length === "number" || $util.isString(message.encryptedContent)))
-                return "encryptedContent: buffer expected";
+        if (message.tbs != null && message.hasOwnProperty("tbs")) {
+            let error = $root.ChannelMessage.TBS.verify(message.tbs);
+            if (error)
+                return "tbs." + error;
+        }
+        if (message.signature != null && message.hasOwnProperty("signature"))
+            if (!(message.signature && typeof message.signature.length === "number" || $util.isString(message.signature)))
+                return "signature: buffer expected";
         return null;
     };
 
@@ -1815,16 +1817,16 @@ export const ChannelMessage = $root.ChannelMessage = (() => {
         if (object instanceof $root.ChannelMessage)
             return object;
         let message = new $root.ChannelMessage();
-        if (object.nonce != null)
-            if (typeof object.nonce === "string")
-                $util.base64.decode(object.nonce, message.nonce = $util.newBuffer($util.base64.length(object.nonce)), 0);
-            else if (object.nonce.length)
-                message.nonce = object.nonce;
-        if (object.encryptedContent != null)
-            if (typeof object.encryptedContent === "string")
-                $util.base64.decode(object.encryptedContent, message.encryptedContent = $util.newBuffer($util.base64.length(object.encryptedContent)), 0);
-            else if (object.encryptedContent.length)
-                message.encryptedContent = object.encryptedContent;
+        if (object.tbs != null) {
+            if (typeof object.tbs !== "object")
+                throw TypeError(".ChannelMessage.tbs: object expected");
+            message.tbs = $root.ChannelMessage.TBS.fromObject(object.tbs);
+        }
+        if (object.signature != null)
+            if (typeof object.signature === "string")
+                $util.base64.decode(object.signature, message.signature = $util.newBuffer($util.base64.length(object.signature)), 0);
+            else if (object.signature.length)
+                message.signature = object.signature;
         return message;
     };
 
@@ -1842,25 +1844,19 @@ export const ChannelMessage = $root.ChannelMessage = (() => {
             options = {};
         let object = {};
         if (options.defaults) {
+            object.tbs = null;
             if (options.bytes === String)
-                object.nonce = "";
+                object.signature = "";
             else {
-                object.nonce = [];
+                object.signature = [];
                 if (options.bytes !== Array)
-                    object.nonce = $util.newBuffer(object.nonce);
-            }
-            if (options.bytes === String)
-                object.encryptedContent = "";
-            else {
-                object.encryptedContent = [];
-                if (options.bytes !== Array)
-                    object.encryptedContent = $util.newBuffer(object.encryptedContent);
+                    object.signature = $util.newBuffer(object.signature);
             }
         }
-        if (message.nonce != null && message.hasOwnProperty("nonce"))
-            object.nonce = options.bytes === String ? $util.base64.encode(message.nonce, 0, message.nonce.length) : options.bytes === Array ? Array.prototype.slice.call(message.nonce) : message.nonce;
-        if (message.encryptedContent != null && message.hasOwnProperty("encryptedContent"))
-            object.encryptedContent = options.bytes === String ? $util.base64.encode(message.encryptedContent, 0, message.encryptedContent.length) : options.bytes === Array ? Array.prototype.slice.call(message.encryptedContent) : message.encryptedContent;
+        if (message.tbs != null && message.hasOwnProperty("tbs"))
+            object.tbs = $root.ChannelMessage.TBS.toObject(message.tbs, options);
+        if (message.signature != null && message.hasOwnProperty("signature"))
+            object.signature = options.bytes === String ? $util.base64.encode(message.signature, 0, message.signature.length) : options.bytes === Array ? Array.prototype.slice.call(message.signature) : message.signature;
         return object;
     };
 
@@ -2274,29 +2270,28 @@ export const ChannelMessage = $root.ChannelMessage = (() => {
         return Body;
     })();
 
-    ChannelMessage.Content = (function() {
+    ChannelMessage.TBS = (function() {
 
         /**
-         * Properties of a Content.
+         * Properties of a TBS.
          * @memberof ChannelMessage
-         * @interface IContent
-         * @property {Array.<Uint8Array>|null} [parents] Content parents
-         * @property {number|Long|null} [height] Content height
-         * @property {Array.<ILink>|null} [chain] Content chain
-         * @property {number|null} [timestamp] Content timestamp
-         * @property {ChannelMessage.IBody|null} [body] Content body
-         * @property {Uint8Array|null} [signature] Content signature
+         * @interface ITBS
+         * @property {Array.<Uint8Array>|null} [parents] TBS parents
+         * @property {number|Long|null} [height] TBS height
+         * @property {Array.<ILink>|null} [chain] TBS chain
+         * @property {number|null} [timestamp] TBS timestamp
+         * @property {ChannelMessage.IBody|null} [body] TBS body
          */
 
         /**
-         * Constructs a new Content.
+         * Constructs a new TBS.
          * @memberof ChannelMessage
-         * @classdesc Represents a Content.
-         * @implements IContent
+         * @classdesc Represents a TBS.
+         * @implements ITBS
          * @constructor
-         * @param {ChannelMessage.IContent=} [properties] Properties to set
+         * @param {ChannelMessage.ITBS=} [properties] Properties to set
          */
-        function Content(properties) {
+        function TBS(properties) {
             this.parents = [];
             this.chain = [];
             if (properties)
@@ -2306,75 +2301,67 @@ export const ChannelMessage = $root.ChannelMessage = (() => {
         }
 
         /**
-         * Content parents.
+         * TBS parents.
          * @member {Array.<Uint8Array>} parents
-         * @memberof ChannelMessage.Content
+         * @memberof ChannelMessage.TBS
          * @instance
          */
-        Content.prototype.parents = $util.emptyArray;
+        TBS.prototype.parents = $util.emptyArray;
 
         /**
-         * Content height.
+         * TBS height.
          * @member {number|Long} height
-         * @memberof ChannelMessage.Content
+         * @memberof ChannelMessage.TBS
          * @instance
          */
-        Content.prototype.height = $util.Long ? $util.Long.fromBits(0,0,false) : 0;
+        TBS.prototype.height = $util.Long ? $util.Long.fromBits(0,0,false) : 0;
 
         /**
-         * Content chain.
+         * TBS chain.
          * @member {Array.<ILink>} chain
-         * @memberof ChannelMessage.Content
+         * @memberof ChannelMessage.TBS
          * @instance
          */
-        Content.prototype.chain = $util.emptyArray;
+        TBS.prototype.chain = $util.emptyArray;
 
         /**
-         * Content timestamp.
+         * TBS timestamp.
          * @member {number} timestamp
-         * @memberof ChannelMessage.Content
+         * @memberof ChannelMessage.TBS
          * @instance
          */
-        Content.prototype.timestamp = 0;
+        TBS.prototype.timestamp = 0;
 
         /**
-         * Content body.
+         * TBS body.
          * @member {ChannelMessage.IBody|null|undefined} body
-         * @memberof ChannelMessage.Content
+         * @memberof ChannelMessage.TBS
          * @instance
          */
-        Content.prototype.body = null;
+        TBS.prototype.body = null;
 
         /**
-         * Content signature.
-         * @member {Uint8Array} signature
-         * @memberof ChannelMessage.Content
-         * @instance
-         */
-        Content.prototype.signature = $util.newBuffer([]);
-
-        /**
-         * Creates a new Content instance using the specified properties.
+         * Creates a new TBS instance using the specified properties.
          * @function create
-         * @memberof ChannelMessage.Content
+         * @memberof ChannelMessage.TBS
          * @static
-         * @param {ChannelMessage.IContent=} [properties] Properties to set
-         * @returns {ChannelMessage.Content} Content instance
+         * @param {ChannelMessage.ITBS=} [properties] Properties to set
+         * @returns {ChannelMessage.TBS} TBS instance
          */
-        Content.create = function create(properties) {
-            return new Content(properties);
+        TBS.create = function create(properties) {
+            return new TBS(properties);
         };
 
         /**
-         * Encodes the specified Content message. Does not implicitly {@link ChannelMessage.Content.verify|verify} messages.
+         * Encodes the specified TBS message. Does not implicitly {@link ChannelMessage.TBS.verify|verify} messages.
          * @function encode
-         * @memberof ChannelMessage.Content
+         * @memberof ChannelMessage.TBS
          * @static
-         * @param {ChannelMessage.IContent} message Content message or plain object to encode
+         * @param {ChannelMessage.ITBS} message TBS message or plain object to encode
          * @param {$protobuf.Writer} [writer] Writer to encode to
          * @returns {$protobuf.Writer} Writer
          */
-        Content.encode = function encode(message, writer) {
+        TBS.encode = function encode(message, writer) {
             if (!writer)
                 writer = $Writer.create();
             if (message.parents != null && message.parents.length)
@@ -2389,39 +2376,37 @@ export const ChannelMessage = $root.ChannelMessage = (() => {
                 writer.uint32(/* id 4, wireType 1 =*/33).double(message.timestamp);
             if (message.body != null && message.hasOwnProperty("body"))
                 $root.ChannelMessage.Body.encode(message.body, writer.uint32(/* id 5, wireType 2 =*/42).fork()).ldelim();
-            if (message.signature != null && message.hasOwnProperty("signature"))
-                writer.uint32(/* id 6, wireType 2 =*/50).bytes(message.signature);
             return writer;
         };
 
         /**
-         * Encodes the specified Content message, length delimited. Does not implicitly {@link ChannelMessage.Content.verify|verify} messages.
+         * Encodes the specified TBS message, length delimited. Does not implicitly {@link ChannelMessage.TBS.verify|verify} messages.
          * @function encodeDelimited
-         * @memberof ChannelMessage.Content
+         * @memberof ChannelMessage.TBS
          * @static
-         * @param {ChannelMessage.IContent} message Content message or plain object to encode
+         * @param {ChannelMessage.ITBS} message TBS message or plain object to encode
          * @param {$protobuf.Writer} [writer] Writer to encode to
          * @returns {$protobuf.Writer} Writer
          */
-        Content.encodeDelimited = function encodeDelimited(message, writer) {
+        TBS.encodeDelimited = function encodeDelimited(message, writer) {
             return this.encode(message, writer).ldelim();
         };
 
         /**
-         * Decodes a Content message from the specified reader or buffer.
+         * Decodes a TBS message from the specified reader or buffer.
          * @function decode
-         * @memberof ChannelMessage.Content
+         * @memberof ChannelMessage.TBS
          * @static
          * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
          * @param {number} [length] Message length if known beforehand
-         * @returns {ChannelMessage.Content} Content
+         * @returns {ChannelMessage.TBS} TBS
          * @throws {Error} If the payload is not a reader or valid buffer
          * @throws {$protobuf.util.ProtocolError} If required fields are missing
          */
-        Content.decode = function decode(reader, length) {
+        TBS.decode = function decode(reader, length) {
             if (!(reader instanceof $Reader))
                 reader = $Reader.create(reader);
-            let end = length === undefined ? reader.len : reader.pos + length, message = new $root.ChannelMessage.Content();
+            let end = length === undefined ? reader.len : reader.pos + length, message = new $root.ChannelMessage.TBS();
             while (reader.pos < end) {
                 let tag = reader.uint32();
                 switch (tag >>> 3) {
@@ -2444,9 +2429,6 @@ export const ChannelMessage = $root.ChannelMessage = (() => {
                 case 5:
                     message.body = $root.ChannelMessage.Body.decode(reader, reader.uint32());
                     break;
-                case 6:
-                    message.signature = reader.bytes();
-                    break;
                 default:
                     reader.skipType(tag & 7);
                     break;
@@ -2456,30 +2438,30 @@ export const ChannelMessage = $root.ChannelMessage = (() => {
         };
 
         /**
-         * Decodes a Content message from the specified reader or buffer, length delimited.
+         * Decodes a TBS message from the specified reader or buffer, length delimited.
          * @function decodeDelimited
-         * @memberof ChannelMessage.Content
+         * @memberof ChannelMessage.TBS
          * @static
          * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
-         * @returns {ChannelMessage.Content} Content
+         * @returns {ChannelMessage.TBS} TBS
          * @throws {Error} If the payload is not a reader or valid buffer
          * @throws {$protobuf.util.ProtocolError} If required fields are missing
          */
-        Content.decodeDelimited = function decodeDelimited(reader) {
+        TBS.decodeDelimited = function decodeDelimited(reader) {
             if (!(reader instanceof $Reader))
                 reader = new $Reader(reader);
             return this.decode(reader, reader.uint32());
         };
 
         /**
-         * Verifies a Content message.
+         * Verifies a TBS message.
          * @function verify
-         * @memberof ChannelMessage.Content
+         * @memberof ChannelMessage.TBS
          * @static
          * @param {Object.<string,*>} message Plain object to verify
          * @returns {string|null} `null` if valid, otherwise the reason why it is not
          */
-        Content.verify = function verify(message) {
+        TBS.verify = function verify(message) {
             if (typeof message !== "object" || message === null)
                 return "object expected";
             if (message.parents != null && message.hasOwnProperty("parents")) {
@@ -2509,27 +2491,24 @@ export const ChannelMessage = $root.ChannelMessage = (() => {
                 if (error)
                     return "body." + error;
             }
-            if (message.signature != null && message.hasOwnProperty("signature"))
-                if (!(message.signature && typeof message.signature.length === "number" || $util.isString(message.signature)))
-                    return "signature: buffer expected";
             return null;
         };
 
         /**
-         * Creates a Content message from a plain object. Also converts values to their respective internal types.
+         * Creates a TBS message from a plain object. Also converts values to their respective internal types.
          * @function fromObject
-         * @memberof ChannelMessage.Content
+         * @memberof ChannelMessage.TBS
          * @static
          * @param {Object.<string,*>} object Plain object
-         * @returns {ChannelMessage.Content} Content
+         * @returns {ChannelMessage.TBS} TBS
          */
-        Content.fromObject = function fromObject(object) {
-            if (object instanceof $root.ChannelMessage.Content)
+        TBS.fromObject = function fromObject(object) {
+            if (object instanceof $root.ChannelMessage.TBS)
                 return object;
-            let message = new $root.ChannelMessage.Content();
+            let message = new $root.ChannelMessage.TBS();
             if (object.parents) {
                 if (!Array.isArray(object.parents))
-                    throw TypeError(".ChannelMessage.Content.parents: array expected");
+                    throw TypeError(".ChannelMessage.TBS.parents: array expected");
                 message.parents = [];
                 for (let i = 0; i < object.parents.length; ++i)
                     if (typeof object.parents[i] === "string")
@@ -2548,11 +2527,11 @@ export const ChannelMessage = $root.ChannelMessage = (() => {
                     message.height = new $util.LongBits(object.height.low >>> 0, object.height.high >>> 0).toNumber();
             if (object.chain) {
                 if (!Array.isArray(object.chain))
-                    throw TypeError(".ChannelMessage.Content.chain: array expected");
+                    throw TypeError(".ChannelMessage.TBS.chain: array expected");
                 message.chain = [];
                 for (let i = 0; i < object.chain.length; ++i) {
                     if (typeof object.chain[i] !== "object")
-                        throw TypeError(".ChannelMessage.Content.chain: object expected");
+                        throw TypeError(".ChannelMessage.TBS.chain: object expected");
                     message.chain[i] = $root.Link.fromObject(object.chain[i]);
                 }
             }
@@ -2560,27 +2539,22 @@ export const ChannelMessage = $root.ChannelMessage = (() => {
                 message.timestamp = Number(object.timestamp);
             if (object.body != null) {
                 if (typeof object.body !== "object")
-                    throw TypeError(".ChannelMessage.Content.body: object expected");
+                    throw TypeError(".ChannelMessage.TBS.body: object expected");
                 message.body = $root.ChannelMessage.Body.fromObject(object.body);
             }
-            if (object.signature != null)
-                if (typeof object.signature === "string")
-                    $util.base64.decode(object.signature, message.signature = $util.newBuffer($util.base64.length(object.signature)), 0);
-                else if (object.signature.length)
-                    message.signature = object.signature;
             return message;
         };
 
         /**
-         * Creates a plain object from a Content message. Also converts values to other types if specified.
+         * Creates a plain object from a TBS message. Also converts values to other types if specified.
          * @function toObject
-         * @memberof ChannelMessage.Content
+         * @memberof ChannelMessage.TBS
          * @static
-         * @param {ChannelMessage.Content} message Content
+         * @param {ChannelMessage.TBS} message TBS
          * @param {$protobuf.IConversionOptions} [options] Conversion options
          * @returns {Object.<string,*>} Plain object
          */
-        Content.toObject = function toObject(message, options) {
+        TBS.toObject = function toObject(message, options) {
             if (!options)
                 options = {};
             let object = {};
@@ -2596,13 +2570,6 @@ export const ChannelMessage = $root.ChannelMessage = (() => {
                     object.height = options.longs === String ? "0" : 0;
                 object.timestamp = 0;
                 object.body = null;
-                if (options.bytes === String)
-                    object.signature = "";
-                else {
-                    object.signature = [];
-                    if (options.bytes !== Array)
-                        object.signature = $util.newBuffer(object.signature);
-                }
             }
             if (message.parents && message.parents.length) {
                 object.parents = [];
@@ -2623,556 +2590,21 @@ export const ChannelMessage = $root.ChannelMessage = (() => {
                 object.timestamp = options.json && !isFinite(message.timestamp) ? String(message.timestamp) : message.timestamp;
             if (message.body != null && message.hasOwnProperty("body"))
                 object.body = $root.ChannelMessage.Body.toObject(message.body, options);
-            if (message.signature != null && message.hasOwnProperty("signature"))
-                object.signature = options.bytes === String ? $util.base64.encode(message.signature, 0, message.signature.length) : options.bytes === Array ? Array.prototype.slice.call(message.signature) : message.signature;
             return object;
         };
 
         /**
-         * Converts this Content to JSON.
+         * Converts this TBS to JSON.
          * @function toJSON
-         * @memberof ChannelMessage.Content
+         * @memberof ChannelMessage.TBS
          * @instance
          * @returns {Object.<string,*>} JSON object
          */
-        Content.prototype.toJSON = function toJSON() {
+        TBS.prototype.toJSON = function toJSON() {
             return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
         };
 
-        Content.TBS = (function() {
-
-            /**
-             * Properties of a TBS.
-             * @memberof ChannelMessage.Content
-             * @interface ITBS
-             * @property {Array.<Uint8Array>|null} [parents] TBS parents
-             * @property {number|Long|null} [height] TBS height
-             * @property {Array.<ILink>|null} [chain] TBS chain
-             * @property {number|null} [timestamp] TBS timestamp
-             * @property {ChannelMessage.IBody|null} [body] TBS body
-             */
-
-            /**
-             * Constructs a new TBS.
-             * @memberof ChannelMessage.Content
-             * @classdesc Represents a TBS.
-             * @implements ITBS
-             * @constructor
-             * @param {ChannelMessage.Content.ITBS=} [properties] Properties to set
-             */
-            function TBS(properties) {
-                this.parents = [];
-                this.chain = [];
-                if (properties)
-                    for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-                        if (properties[keys[i]] != null)
-                            this[keys[i]] = properties[keys[i]];
-            }
-
-            /**
-             * TBS parents.
-             * @member {Array.<Uint8Array>} parents
-             * @memberof ChannelMessage.Content.TBS
-             * @instance
-             */
-            TBS.prototype.parents = $util.emptyArray;
-
-            /**
-             * TBS height.
-             * @member {number|Long} height
-             * @memberof ChannelMessage.Content.TBS
-             * @instance
-             */
-            TBS.prototype.height = $util.Long ? $util.Long.fromBits(0,0,false) : 0;
-
-            /**
-             * TBS chain.
-             * @member {Array.<ILink>} chain
-             * @memberof ChannelMessage.Content.TBS
-             * @instance
-             */
-            TBS.prototype.chain = $util.emptyArray;
-
-            /**
-             * TBS timestamp.
-             * @member {number} timestamp
-             * @memberof ChannelMessage.Content.TBS
-             * @instance
-             */
-            TBS.prototype.timestamp = 0;
-
-            /**
-             * TBS body.
-             * @member {ChannelMessage.IBody|null|undefined} body
-             * @memberof ChannelMessage.Content.TBS
-             * @instance
-             */
-            TBS.prototype.body = null;
-
-            /**
-             * Creates a new TBS instance using the specified properties.
-             * @function create
-             * @memberof ChannelMessage.Content.TBS
-             * @static
-             * @param {ChannelMessage.Content.ITBS=} [properties] Properties to set
-             * @returns {ChannelMessage.Content.TBS} TBS instance
-             */
-            TBS.create = function create(properties) {
-                return new TBS(properties);
-            };
-
-            /**
-             * Encodes the specified TBS message. Does not implicitly {@link ChannelMessage.Content.TBS.verify|verify} messages.
-             * @function encode
-             * @memberof ChannelMessage.Content.TBS
-             * @static
-             * @param {ChannelMessage.Content.ITBS} message TBS message or plain object to encode
-             * @param {$protobuf.Writer} [writer] Writer to encode to
-             * @returns {$protobuf.Writer} Writer
-             */
-            TBS.encode = function encode(message, writer) {
-                if (!writer)
-                    writer = $Writer.create();
-                if (message.parents != null && message.parents.length)
-                    for (let i = 0; i < message.parents.length; ++i)
-                        writer.uint32(/* id 1, wireType 2 =*/10).bytes(message.parents[i]);
-                if (message.height != null && message.hasOwnProperty("height"))
-                    writer.uint32(/* id 2, wireType 0 =*/16).int64(message.height);
-                if (message.chain != null && message.chain.length)
-                    for (let i = 0; i < message.chain.length; ++i)
-                        $root.Link.encode(message.chain[i], writer.uint32(/* id 3, wireType 2 =*/26).fork()).ldelim();
-                if (message.timestamp != null && message.hasOwnProperty("timestamp"))
-                    writer.uint32(/* id 4, wireType 1 =*/33).double(message.timestamp);
-                if (message.body != null && message.hasOwnProperty("body"))
-                    $root.ChannelMessage.Body.encode(message.body, writer.uint32(/* id 5, wireType 2 =*/42).fork()).ldelim();
-                return writer;
-            };
-
-            /**
-             * Encodes the specified TBS message, length delimited. Does not implicitly {@link ChannelMessage.Content.TBS.verify|verify} messages.
-             * @function encodeDelimited
-             * @memberof ChannelMessage.Content.TBS
-             * @static
-             * @param {ChannelMessage.Content.ITBS} message TBS message or plain object to encode
-             * @param {$protobuf.Writer} [writer] Writer to encode to
-             * @returns {$protobuf.Writer} Writer
-             */
-            TBS.encodeDelimited = function encodeDelimited(message, writer) {
-                return this.encode(message, writer).ldelim();
-            };
-
-            /**
-             * Decodes a TBS message from the specified reader or buffer.
-             * @function decode
-             * @memberof ChannelMessage.Content.TBS
-             * @static
-             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
-             * @param {number} [length] Message length if known beforehand
-             * @returns {ChannelMessage.Content.TBS} TBS
-             * @throws {Error} If the payload is not a reader or valid buffer
-             * @throws {$protobuf.util.ProtocolError} If required fields are missing
-             */
-            TBS.decode = function decode(reader, length) {
-                if (!(reader instanceof $Reader))
-                    reader = $Reader.create(reader);
-                let end = length === undefined ? reader.len : reader.pos + length, message = new $root.ChannelMessage.Content.TBS();
-                while (reader.pos < end) {
-                    let tag = reader.uint32();
-                    switch (tag >>> 3) {
-                    case 1:
-                        if (!(message.parents && message.parents.length))
-                            message.parents = [];
-                        message.parents.push(reader.bytes());
-                        break;
-                    case 2:
-                        message.height = reader.int64();
-                        break;
-                    case 3:
-                        if (!(message.chain && message.chain.length))
-                            message.chain = [];
-                        message.chain.push($root.Link.decode(reader, reader.uint32()));
-                        break;
-                    case 4:
-                        message.timestamp = reader.double();
-                        break;
-                    case 5:
-                        message.body = $root.ChannelMessage.Body.decode(reader, reader.uint32());
-                        break;
-                    default:
-                        reader.skipType(tag & 7);
-                        break;
-                    }
-                }
-                return message;
-            };
-
-            /**
-             * Decodes a TBS message from the specified reader or buffer, length delimited.
-             * @function decodeDelimited
-             * @memberof ChannelMessage.Content.TBS
-             * @static
-             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
-             * @returns {ChannelMessage.Content.TBS} TBS
-             * @throws {Error} If the payload is not a reader or valid buffer
-             * @throws {$protobuf.util.ProtocolError} If required fields are missing
-             */
-            TBS.decodeDelimited = function decodeDelimited(reader) {
-                if (!(reader instanceof $Reader))
-                    reader = new $Reader(reader);
-                return this.decode(reader, reader.uint32());
-            };
-
-            /**
-             * Verifies a TBS message.
-             * @function verify
-             * @memberof ChannelMessage.Content.TBS
-             * @static
-             * @param {Object.<string,*>} message Plain object to verify
-             * @returns {string|null} `null` if valid, otherwise the reason why it is not
-             */
-            TBS.verify = function verify(message) {
-                if (typeof message !== "object" || message === null)
-                    return "object expected";
-                if (message.parents != null && message.hasOwnProperty("parents")) {
-                    if (!Array.isArray(message.parents))
-                        return "parents: array expected";
-                    for (let i = 0; i < message.parents.length; ++i)
-                        if (!(message.parents[i] && typeof message.parents[i].length === "number" || $util.isString(message.parents[i])))
-                            return "parents: buffer[] expected";
-                }
-                if (message.height != null && message.hasOwnProperty("height"))
-                    if (!$util.isInteger(message.height) && !(message.height && $util.isInteger(message.height.low) && $util.isInteger(message.height.high)))
-                        return "height: integer|Long expected";
-                if (message.chain != null && message.hasOwnProperty("chain")) {
-                    if (!Array.isArray(message.chain))
-                        return "chain: array expected";
-                    for (let i = 0; i < message.chain.length; ++i) {
-                        let error = $root.Link.verify(message.chain[i]);
-                        if (error)
-                            return "chain." + error;
-                    }
-                }
-                if (message.timestamp != null && message.hasOwnProperty("timestamp"))
-                    if (typeof message.timestamp !== "number")
-                        return "timestamp: number expected";
-                if (message.body != null && message.hasOwnProperty("body")) {
-                    let error = $root.ChannelMessage.Body.verify(message.body);
-                    if (error)
-                        return "body." + error;
-                }
-                return null;
-            };
-
-            /**
-             * Creates a TBS message from a plain object. Also converts values to their respective internal types.
-             * @function fromObject
-             * @memberof ChannelMessage.Content.TBS
-             * @static
-             * @param {Object.<string,*>} object Plain object
-             * @returns {ChannelMessage.Content.TBS} TBS
-             */
-            TBS.fromObject = function fromObject(object) {
-                if (object instanceof $root.ChannelMessage.Content.TBS)
-                    return object;
-                let message = new $root.ChannelMessage.Content.TBS();
-                if (object.parents) {
-                    if (!Array.isArray(object.parents))
-                        throw TypeError(".ChannelMessage.Content.TBS.parents: array expected");
-                    message.parents = [];
-                    for (let i = 0; i < object.parents.length; ++i)
-                        if (typeof object.parents[i] === "string")
-                            $util.base64.decode(object.parents[i], message.parents[i] = $util.newBuffer($util.base64.length(object.parents[i])), 0);
-                        else if (object.parents[i].length)
-                            message.parents[i] = object.parents[i];
-                }
-                if (object.height != null)
-                    if ($util.Long)
-                        (message.height = $util.Long.fromValue(object.height)).unsigned = false;
-                    else if (typeof object.height === "string")
-                        message.height = parseInt(object.height, 10);
-                    else if (typeof object.height === "number")
-                        message.height = object.height;
-                    else if (typeof object.height === "object")
-                        message.height = new $util.LongBits(object.height.low >>> 0, object.height.high >>> 0).toNumber();
-                if (object.chain) {
-                    if (!Array.isArray(object.chain))
-                        throw TypeError(".ChannelMessage.Content.TBS.chain: array expected");
-                    message.chain = [];
-                    for (let i = 0; i < object.chain.length; ++i) {
-                        if (typeof object.chain[i] !== "object")
-                            throw TypeError(".ChannelMessage.Content.TBS.chain: object expected");
-                        message.chain[i] = $root.Link.fromObject(object.chain[i]);
-                    }
-                }
-                if (object.timestamp != null)
-                    message.timestamp = Number(object.timestamp);
-                if (object.body != null) {
-                    if (typeof object.body !== "object")
-                        throw TypeError(".ChannelMessage.Content.TBS.body: object expected");
-                    message.body = $root.ChannelMessage.Body.fromObject(object.body);
-                }
-                return message;
-            };
-
-            /**
-             * Creates a plain object from a TBS message. Also converts values to other types if specified.
-             * @function toObject
-             * @memberof ChannelMessage.Content.TBS
-             * @static
-             * @param {ChannelMessage.Content.TBS} message TBS
-             * @param {$protobuf.IConversionOptions} [options] Conversion options
-             * @returns {Object.<string,*>} Plain object
-             */
-            TBS.toObject = function toObject(message, options) {
-                if (!options)
-                    options = {};
-                let object = {};
-                if (options.arrays || options.defaults) {
-                    object.parents = [];
-                    object.chain = [];
-                }
-                if (options.defaults) {
-                    if ($util.Long) {
-                        let long = new $util.Long(0, 0, false);
-                        object.height = options.longs === String ? long.toString() : options.longs === Number ? long.toNumber() : long;
-                    } else
-                        object.height = options.longs === String ? "0" : 0;
-                    object.timestamp = 0;
-                    object.body = null;
-                }
-                if (message.parents && message.parents.length) {
-                    object.parents = [];
-                    for (let j = 0; j < message.parents.length; ++j)
-                        object.parents[j] = options.bytes === String ? $util.base64.encode(message.parents[j], 0, message.parents[j].length) : options.bytes === Array ? Array.prototype.slice.call(message.parents[j]) : message.parents[j];
-                }
-                if (message.height != null && message.hasOwnProperty("height"))
-                    if (typeof message.height === "number")
-                        object.height = options.longs === String ? String(message.height) : message.height;
-                    else
-                        object.height = options.longs === String ? $util.Long.prototype.toString.call(message.height) : options.longs === Number ? new $util.LongBits(message.height.low >>> 0, message.height.high >>> 0).toNumber() : message.height;
-                if (message.chain && message.chain.length) {
-                    object.chain = [];
-                    for (let j = 0; j < message.chain.length; ++j)
-                        object.chain[j] = $root.Link.toObject(message.chain[j], options);
-                }
-                if (message.timestamp != null && message.hasOwnProperty("timestamp"))
-                    object.timestamp = options.json && !isFinite(message.timestamp) ? String(message.timestamp) : message.timestamp;
-                if (message.body != null && message.hasOwnProperty("body"))
-                    object.body = $root.ChannelMessage.Body.toObject(message.body, options);
-                return object;
-            };
-
-            /**
-             * Converts this TBS to JSON.
-             * @function toJSON
-             * @memberof ChannelMessage.Content.TBS
-             * @instance
-             * @returns {Object.<string,*>} JSON object
-             */
-            TBS.prototype.toJSON = function toJSON() {
-                return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
-            };
-
-            return TBS;
-        })();
-
-        return Content;
-    })();
-
-    ChannelMessage.EncryptionKeyInput = (function() {
-
-        /**
-         * Properties of an EncryptionKeyInput.
-         * @memberof ChannelMessage
-         * @interface IEncryptionKeyInput
-         * @property {Uint8Array|null} [channelPubKey] EncryptionKeyInput channelPubKey
-         */
-
-        /**
-         * Constructs a new EncryptionKeyInput.
-         * @memberof ChannelMessage
-         * @classdesc Represents an EncryptionKeyInput.
-         * @implements IEncryptionKeyInput
-         * @constructor
-         * @param {ChannelMessage.IEncryptionKeyInput=} [properties] Properties to set
-         */
-        function EncryptionKeyInput(properties) {
-            if (properties)
-                for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-                    if (properties[keys[i]] != null)
-                        this[keys[i]] = properties[keys[i]];
-        }
-
-        /**
-         * EncryptionKeyInput channelPubKey.
-         * @member {Uint8Array} channelPubKey
-         * @memberof ChannelMessage.EncryptionKeyInput
-         * @instance
-         */
-        EncryptionKeyInput.prototype.channelPubKey = $util.newBuffer([]);
-
-        /**
-         * Creates a new EncryptionKeyInput instance using the specified properties.
-         * @function create
-         * @memberof ChannelMessage.EncryptionKeyInput
-         * @static
-         * @param {ChannelMessage.IEncryptionKeyInput=} [properties] Properties to set
-         * @returns {ChannelMessage.EncryptionKeyInput} EncryptionKeyInput instance
-         */
-        EncryptionKeyInput.create = function create(properties) {
-            return new EncryptionKeyInput(properties);
-        };
-
-        /**
-         * Encodes the specified EncryptionKeyInput message. Does not implicitly {@link ChannelMessage.EncryptionKeyInput.verify|verify} messages.
-         * @function encode
-         * @memberof ChannelMessage.EncryptionKeyInput
-         * @static
-         * @param {ChannelMessage.IEncryptionKeyInput} message EncryptionKeyInput message or plain object to encode
-         * @param {$protobuf.Writer} [writer] Writer to encode to
-         * @returns {$protobuf.Writer} Writer
-         */
-        EncryptionKeyInput.encode = function encode(message, writer) {
-            if (!writer)
-                writer = $Writer.create();
-            if (message.channelPubKey != null && message.hasOwnProperty("channelPubKey"))
-                writer.uint32(/* id 1, wireType 2 =*/10).bytes(message.channelPubKey);
-            return writer;
-        };
-
-        /**
-         * Encodes the specified EncryptionKeyInput message, length delimited. Does not implicitly {@link ChannelMessage.EncryptionKeyInput.verify|verify} messages.
-         * @function encodeDelimited
-         * @memberof ChannelMessage.EncryptionKeyInput
-         * @static
-         * @param {ChannelMessage.IEncryptionKeyInput} message EncryptionKeyInput message or plain object to encode
-         * @param {$protobuf.Writer} [writer] Writer to encode to
-         * @returns {$protobuf.Writer} Writer
-         */
-        EncryptionKeyInput.encodeDelimited = function encodeDelimited(message, writer) {
-            return this.encode(message, writer).ldelim();
-        };
-
-        /**
-         * Decodes an EncryptionKeyInput message from the specified reader or buffer.
-         * @function decode
-         * @memberof ChannelMessage.EncryptionKeyInput
-         * @static
-         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
-         * @param {number} [length] Message length if known beforehand
-         * @returns {ChannelMessage.EncryptionKeyInput} EncryptionKeyInput
-         * @throws {Error} If the payload is not a reader or valid buffer
-         * @throws {$protobuf.util.ProtocolError} If required fields are missing
-         */
-        EncryptionKeyInput.decode = function decode(reader, length) {
-            if (!(reader instanceof $Reader))
-                reader = $Reader.create(reader);
-            let end = length === undefined ? reader.len : reader.pos + length, message = new $root.ChannelMessage.EncryptionKeyInput();
-            while (reader.pos < end) {
-                let tag = reader.uint32();
-                switch (tag >>> 3) {
-                case 1:
-                    message.channelPubKey = reader.bytes();
-                    break;
-                default:
-                    reader.skipType(tag & 7);
-                    break;
-                }
-            }
-            return message;
-        };
-
-        /**
-         * Decodes an EncryptionKeyInput message from the specified reader or buffer, length delimited.
-         * @function decodeDelimited
-         * @memberof ChannelMessage.EncryptionKeyInput
-         * @static
-         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
-         * @returns {ChannelMessage.EncryptionKeyInput} EncryptionKeyInput
-         * @throws {Error} If the payload is not a reader or valid buffer
-         * @throws {$protobuf.util.ProtocolError} If required fields are missing
-         */
-        EncryptionKeyInput.decodeDelimited = function decodeDelimited(reader) {
-            if (!(reader instanceof $Reader))
-                reader = new $Reader(reader);
-            return this.decode(reader, reader.uint32());
-        };
-
-        /**
-         * Verifies an EncryptionKeyInput message.
-         * @function verify
-         * @memberof ChannelMessage.EncryptionKeyInput
-         * @static
-         * @param {Object.<string,*>} message Plain object to verify
-         * @returns {string|null} `null` if valid, otherwise the reason why it is not
-         */
-        EncryptionKeyInput.verify = function verify(message) {
-            if (typeof message !== "object" || message === null)
-                return "object expected";
-            if (message.channelPubKey != null && message.hasOwnProperty("channelPubKey"))
-                if (!(message.channelPubKey && typeof message.channelPubKey.length === "number" || $util.isString(message.channelPubKey)))
-                    return "channelPubKey: buffer expected";
-            return null;
-        };
-
-        /**
-         * Creates an EncryptionKeyInput message from a plain object. Also converts values to their respective internal types.
-         * @function fromObject
-         * @memberof ChannelMessage.EncryptionKeyInput
-         * @static
-         * @param {Object.<string,*>} object Plain object
-         * @returns {ChannelMessage.EncryptionKeyInput} EncryptionKeyInput
-         */
-        EncryptionKeyInput.fromObject = function fromObject(object) {
-            if (object instanceof $root.ChannelMessage.EncryptionKeyInput)
-                return object;
-            let message = new $root.ChannelMessage.EncryptionKeyInput();
-            if (object.channelPubKey != null)
-                if (typeof object.channelPubKey === "string")
-                    $util.base64.decode(object.channelPubKey, message.channelPubKey = $util.newBuffer($util.base64.length(object.channelPubKey)), 0);
-                else if (object.channelPubKey.length)
-                    message.channelPubKey = object.channelPubKey;
-            return message;
-        };
-
-        /**
-         * Creates a plain object from an EncryptionKeyInput message. Also converts values to other types if specified.
-         * @function toObject
-         * @memberof ChannelMessage.EncryptionKeyInput
-         * @static
-         * @param {ChannelMessage.EncryptionKeyInput} message EncryptionKeyInput
-         * @param {$protobuf.IConversionOptions} [options] Conversion options
-         * @returns {Object.<string,*>} Plain object
-         */
-        EncryptionKeyInput.toObject = function toObject(message, options) {
-            if (!options)
-                options = {};
-            let object = {};
-            if (options.defaults)
-                if (options.bytes === String)
-                    object.channelPubKey = "";
-                else {
-                    object.channelPubKey = [];
-                    if (options.bytes !== Array)
-                        object.channelPubKey = $util.newBuffer(object.channelPubKey);
-                }
-            if (message.channelPubKey != null && message.hasOwnProperty("channelPubKey"))
-                object.channelPubKey = options.bytes === String ? $util.base64.encode(message.channelPubKey, 0, message.channelPubKey.length) : options.bytes === Array ? Array.prototype.slice.call(message.channelPubKey) : message.channelPubKey;
-            return object;
-        };
-
-        /**
-         * Converts this EncryptionKeyInput to JSON.
-         * @function toJSON
-         * @memberof ChannelMessage.EncryptionKeyInput
-         * @instance
-         * @returns {Object.<string,*>} JSON object
-         */
-        EncryptionKeyInput.prototype.toJSON = function toJSON() {
-            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
-        };
-
-        return EncryptionKeyInput;
+        return TBS;
     })();
 
     return ChannelMessage;

--- a/lib/messages.js
+++ b/lib/messages.js
@@ -2616,7 +2616,6 @@ export const Query = $root.Query = (() => {
      * Properties of a Query.
      * @exports IQuery
      * @interface IQuery
-     * @property {Array.<ILink>|null} [chain] Query chain
      * @property {number|Long|null} [height] Query height
      * @property {Uint8Array|null} [hash] Query hash
      * @property {boolean|null} [isBackward] Query isBackward
@@ -2632,20 +2631,11 @@ export const Query = $root.Query = (() => {
      * @param {IQuery=} [properties] Properties to set
      */
     function Query(properties) {
-        this.chain = [];
         if (properties)
             for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
                 if (properties[keys[i]] != null)
                     this[keys[i]] = properties[keys[i]];
     }
-
-    /**
-     * Query chain.
-     * @member {Array.<ILink>} chain
-     * @memberof Query
-     * @instance
-     */
-    Query.prototype.chain = $util.emptyArray;
 
     /**
      * Query height.
@@ -2717,17 +2707,14 @@ export const Query = $root.Query = (() => {
     Query.encode = function encode(message, writer) {
         if (!writer)
             writer = $Writer.create();
-        if (message.chain != null && message.chain.length)
-            for (let i = 0; i < message.chain.length; ++i)
-                $root.Link.encode(message.chain[i], writer.uint32(/* id 1, wireType 2 =*/10).fork()).ldelim();
         if (message.height != null && message.hasOwnProperty("height"))
-            writer.uint32(/* id 2, wireType 0 =*/16).int64(message.height);
+            writer.uint32(/* id 1, wireType 0 =*/8).int64(message.height);
         if (message.hash != null && message.hasOwnProperty("hash"))
-            writer.uint32(/* id 3, wireType 2 =*/26).bytes(message.hash);
+            writer.uint32(/* id 2, wireType 2 =*/18).bytes(message.hash);
         if (message.isBackward != null && message.hasOwnProperty("isBackward"))
-            writer.uint32(/* id 4, wireType 0 =*/32).bool(message.isBackward);
+            writer.uint32(/* id 3, wireType 0 =*/24).bool(message.isBackward);
         if (message.limit != null && message.hasOwnProperty("limit"))
-            writer.uint32(/* id 5, wireType 0 =*/40).uint32(message.limit);
+            writer.uint32(/* id 4, wireType 0 =*/32).uint32(message.limit);
         return writer;
     };
 
@@ -2763,20 +2750,15 @@ export const Query = $root.Query = (() => {
             let tag = reader.uint32();
             switch (tag >>> 3) {
             case 1:
-                if (!(message.chain && message.chain.length))
-                    message.chain = [];
-                message.chain.push($root.Link.decode(reader, reader.uint32()));
-                break;
-            case 2:
                 message.height = reader.int64();
                 break;
-            case 3:
+            case 2:
                 message.hash = reader.bytes();
                 break;
-            case 4:
+            case 3:
                 message.isBackward = reader.bool();
                 break;
-            case 5:
+            case 4:
                 message.limit = reader.uint32();
                 break;
             default:
@@ -2815,15 +2797,6 @@ export const Query = $root.Query = (() => {
         if (typeof message !== "object" || message === null)
             return "object expected";
         let properties = {};
-        if (message.chain != null && message.hasOwnProperty("chain")) {
-            if (!Array.isArray(message.chain))
-                return "chain: array expected";
-            for (let i = 0; i < message.chain.length; ++i) {
-                let error = $root.Link.verify(message.chain[i]);
-                if (error)
-                    return "chain." + error;
-            }
-        }
         if (message.height != null && message.hasOwnProperty("height")) {
             properties.cursor = 1;
             if (!$util.isInteger(message.height) && !(message.height && $util.isInteger(message.height.low) && $util.isInteger(message.height.high)))
@@ -2857,16 +2830,6 @@ export const Query = $root.Query = (() => {
         if (object instanceof $root.Query)
             return object;
         let message = new $root.Query();
-        if (object.chain) {
-            if (!Array.isArray(object.chain))
-                throw TypeError(".Query.chain: array expected");
-            message.chain = [];
-            for (let i = 0; i < object.chain.length; ++i) {
-                if (typeof object.chain[i] !== "object")
-                    throw TypeError(".Query.chain: object expected");
-                message.chain[i] = $root.Link.fromObject(object.chain[i]);
-            }
-        }
         if (object.height != null)
             if ($util.Long)
                 (message.height = $util.Long.fromValue(object.height)).unsigned = false;
@@ -2901,16 +2864,9 @@ export const Query = $root.Query = (() => {
         if (!options)
             options = {};
         let object = {};
-        if (options.arrays || options.defaults)
-            object.chain = [];
         if (options.defaults) {
             object.isBackward = false;
             object.limit = 0;
-        }
-        if (message.chain && message.chain.length) {
-            object.chain = [];
-            for (let j = 0; j < message.chain.length; ++j)
-                object.chain[j] = $root.Link.toObject(message.chain[j], options);
         }
         if (message.height != null && message.hasOwnProperty("height")) {
             if (typeof message.height === "number")
@@ -3462,7 +3418,6 @@ export const Bulk = $root.Bulk = (() => {
      * Properties of a Bulk.
      * @exports IBulk
      * @interface IBulk
-     * @property {Array.<ILink>|null} [chain] Bulk chain
      * @property {Array.<Uint8Array>|null} [hashes] Bulk hashes
      */
 
@@ -3475,21 +3430,12 @@ export const Bulk = $root.Bulk = (() => {
      * @param {IBulk=} [properties] Properties to set
      */
     function Bulk(properties) {
-        this.chain = [];
         this.hashes = [];
         if (properties)
             for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
                 if (properties[keys[i]] != null)
                     this[keys[i]] = properties[keys[i]];
     }
-
-    /**
-     * Bulk chain.
-     * @member {Array.<ILink>} chain
-     * @memberof Bulk
-     * @instance
-     */
-    Bulk.prototype.chain = $util.emptyArray;
 
     /**
      * Bulk hashes.
@@ -3523,12 +3469,9 @@ export const Bulk = $root.Bulk = (() => {
     Bulk.encode = function encode(message, writer) {
         if (!writer)
             writer = $Writer.create();
-        if (message.chain != null && message.chain.length)
-            for (let i = 0; i < message.chain.length; ++i)
-                $root.Link.encode(message.chain[i], writer.uint32(/* id 1, wireType 2 =*/10).fork()).ldelim();
         if (message.hashes != null && message.hashes.length)
             for (let i = 0; i < message.hashes.length; ++i)
-                writer.uint32(/* id 2, wireType 2 =*/18).bytes(message.hashes[i]);
+                writer.uint32(/* id 1, wireType 2 =*/10).bytes(message.hashes[i]);
         return writer;
     };
 
@@ -3564,11 +3507,6 @@ export const Bulk = $root.Bulk = (() => {
             let tag = reader.uint32();
             switch (tag >>> 3) {
             case 1:
-                if (!(message.chain && message.chain.length))
-                    message.chain = [];
-                message.chain.push($root.Link.decode(reader, reader.uint32()));
-                break;
-            case 2:
                 if (!(message.hashes && message.hashes.length))
                     message.hashes = [];
                 message.hashes.push(reader.bytes());
@@ -3608,15 +3546,6 @@ export const Bulk = $root.Bulk = (() => {
     Bulk.verify = function verify(message) {
         if (typeof message !== "object" || message === null)
             return "object expected";
-        if (message.chain != null && message.hasOwnProperty("chain")) {
-            if (!Array.isArray(message.chain))
-                return "chain: array expected";
-            for (let i = 0; i < message.chain.length; ++i) {
-                let error = $root.Link.verify(message.chain[i]);
-                if (error)
-                    return "chain." + error;
-            }
-        }
         if (message.hashes != null && message.hasOwnProperty("hashes")) {
             if (!Array.isArray(message.hashes))
                 return "hashes: array expected";
@@ -3639,16 +3568,6 @@ export const Bulk = $root.Bulk = (() => {
         if (object instanceof $root.Bulk)
             return object;
         let message = new $root.Bulk();
-        if (object.chain) {
-            if (!Array.isArray(object.chain))
-                throw TypeError(".Bulk.chain: array expected");
-            message.chain = [];
-            for (let i = 0; i < object.chain.length; ++i) {
-                if (typeof object.chain[i] !== "object")
-                    throw TypeError(".Bulk.chain: object expected");
-                message.chain[i] = $root.Link.fromObject(object.chain[i]);
-            }
-        }
         if (object.hashes) {
             if (!Array.isArray(object.hashes))
                 throw TypeError(".Bulk.hashes: array expected");
@@ -3675,15 +3594,8 @@ export const Bulk = $root.Bulk = (() => {
         if (!options)
             options = {};
         let object = {};
-        if (options.arrays || options.defaults) {
-            object.chain = [];
+        if (options.arrays || options.defaults)
             object.hashes = [];
-        }
-        if (message.chain && message.chain.length) {
-            object.chain = [];
-            for (let j = 0; j < message.chain.length; ++j)
-                object.chain[j] = $root.Link.toObject(message.chain[j], options);
-        }
         if (message.hashes && message.hashes.length) {
             object.hashes = [];
             for (let j = 0; j < message.hashes.length; ++j)
@@ -3937,6 +3849,1071 @@ export const BulkResponse = $root.BulkResponse = (() => {
     return BulkResponse;
 })();
 
+export const SyncRequest = $root.SyncRequest = (() => {
+
+    /**
+     * Properties of a SyncRequest.
+     * @exports ISyncRequest
+     * @interface ISyncRequest
+     * @property {Uint8Array|null} [channelId] SyncRequest channelId
+     * @property {number|null} [seq] SyncRequest seq
+     * @property {Array.<ILink>|null} [chain] SyncRequest chain
+     * @property {Uint8Array|null} [nonce] SyncRequest nonce
+     * @property {Uint8Array|null} [box] SyncRequest box
+     */
+
+    /**
+     * Constructs a new SyncRequest.
+     * @exports SyncRequest
+     * @classdesc Represents a SyncRequest.
+     * @implements ISyncRequest
+     * @constructor
+     * @param {ISyncRequest=} [properties] Properties to set
+     */
+    function SyncRequest(properties) {
+        this.chain = [];
+        if (properties)
+            for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                if (properties[keys[i]] != null)
+                    this[keys[i]] = properties[keys[i]];
+    }
+
+    /**
+     * SyncRequest channelId.
+     * @member {Uint8Array} channelId
+     * @memberof SyncRequest
+     * @instance
+     */
+    SyncRequest.prototype.channelId = $util.newBuffer([]);
+
+    /**
+     * SyncRequest seq.
+     * @member {number} seq
+     * @memberof SyncRequest
+     * @instance
+     */
+    SyncRequest.prototype.seq = 0;
+
+    /**
+     * SyncRequest chain.
+     * @member {Array.<ILink>} chain
+     * @memberof SyncRequest
+     * @instance
+     */
+    SyncRequest.prototype.chain = $util.emptyArray;
+
+    /**
+     * SyncRequest nonce.
+     * @member {Uint8Array} nonce
+     * @memberof SyncRequest
+     * @instance
+     */
+    SyncRequest.prototype.nonce = $util.newBuffer([]);
+
+    /**
+     * SyncRequest box.
+     * @member {Uint8Array} box
+     * @memberof SyncRequest
+     * @instance
+     */
+    SyncRequest.prototype.box = $util.newBuffer([]);
+
+    /**
+     * Creates a new SyncRequest instance using the specified properties.
+     * @function create
+     * @memberof SyncRequest
+     * @static
+     * @param {ISyncRequest=} [properties] Properties to set
+     * @returns {SyncRequest} SyncRequest instance
+     */
+    SyncRequest.create = function create(properties) {
+        return new SyncRequest(properties);
+    };
+
+    /**
+     * Encodes the specified SyncRequest message. Does not implicitly {@link SyncRequest.verify|verify} messages.
+     * @function encode
+     * @memberof SyncRequest
+     * @static
+     * @param {ISyncRequest} message SyncRequest message or plain object to encode
+     * @param {$protobuf.Writer} [writer] Writer to encode to
+     * @returns {$protobuf.Writer} Writer
+     */
+    SyncRequest.encode = function encode(message, writer) {
+        if (!writer)
+            writer = $Writer.create();
+        if (message.channelId != null && message.hasOwnProperty("channelId"))
+            writer.uint32(/* id 1, wireType 2 =*/10).bytes(message.channelId);
+        if (message.seq != null && message.hasOwnProperty("seq"))
+            writer.uint32(/* id 2, wireType 0 =*/16).uint32(message.seq);
+        if (message.chain != null && message.chain.length)
+            for (let i = 0; i < message.chain.length; ++i)
+                $root.Link.encode(message.chain[i], writer.uint32(/* id 3, wireType 2 =*/26).fork()).ldelim();
+        if (message.nonce != null && message.hasOwnProperty("nonce"))
+            writer.uint32(/* id 4, wireType 2 =*/34).bytes(message.nonce);
+        if (message.box != null && message.hasOwnProperty("box"))
+            writer.uint32(/* id 5, wireType 2 =*/42).bytes(message.box);
+        return writer;
+    };
+
+    /**
+     * Encodes the specified SyncRequest message, length delimited. Does not implicitly {@link SyncRequest.verify|verify} messages.
+     * @function encodeDelimited
+     * @memberof SyncRequest
+     * @static
+     * @param {ISyncRequest} message SyncRequest message or plain object to encode
+     * @param {$protobuf.Writer} [writer] Writer to encode to
+     * @returns {$protobuf.Writer} Writer
+     */
+    SyncRequest.encodeDelimited = function encodeDelimited(message, writer) {
+        return this.encode(message, writer).ldelim();
+    };
+
+    /**
+     * Decodes a SyncRequest message from the specified reader or buffer.
+     * @function decode
+     * @memberof SyncRequest
+     * @static
+     * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+     * @param {number} [length] Message length if known beforehand
+     * @returns {SyncRequest} SyncRequest
+     * @throws {Error} If the payload is not a reader or valid buffer
+     * @throws {$protobuf.util.ProtocolError} If required fields are missing
+     */
+    SyncRequest.decode = function decode(reader, length) {
+        if (!(reader instanceof $Reader))
+            reader = $Reader.create(reader);
+        let end = length === undefined ? reader.len : reader.pos + length, message = new $root.SyncRequest();
+        while (reader.pos < end) {
+            let tag = reader.uint32();
+            switch (tag >>> 3) {
+            case 1:
+                message.channelId = reader.bytes();
+                break;
+            case 2:
+                message.seq = reader.uint32();
+                break;
+            case 3:
+                if (!(message.chain && message.chain.length))
+                    message.chain = [];
+                message.chain.push($root.Link.decode(reader, reader.uint32()));
+                break;
+            case 4:
+                message.nonce = reader.bytes();
+                break;
+            case 5:
+                message.box = reader.bytes();
+                break;
+            default:
+                reader.skipType(tag & 7);
+                break;
+            }
+        }
+        return message;
+    };
+
+    /**
+     * Decodes a SyncRequest message from the specified reader or buffer, length delimited.
+     * @function decodeDelimited
+     * @memberof SyncRequest
+     * @static
+     * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+     * @returns {SyncRequest} SyncRequest
+     * @throws {Error} If the payload is not a reader or valid buffer
+     * @throws {$protobuf.util.ProtocolError} If required fields are missing
+     */
+    SyncRequest.decodeDelimited = function decodeDelimited(reader) {
+        if (!(reader instanceof $Reader))
+            reader = new $Reader(reader);
+        return this.decode(reader, reader.uint32());
+    };
+
+    /**
+     * Verifies a SyncRequest message.
+     * @function verify
+     * @memberof SyncRequest
+     * @static
+     * @param {Object.<string,*>} message Plain object to verify
+     * @returns {string|null} `null` if valid, otherwise the reason why it is not
+     */
+    SyncRequest.verify = function verify(message) {
+        if (typeof message !== "object" || message === null)
+            return "object expected";
+        if (message.channelId != null && message.hasOwnProperty("channelId"))
+            if (!(message.channelId && typeof message.channelId.length === "number" || $util.isString(message.channelId)))
+                return "channelId: buffer expected";
+        if (message.seq != null && message.hasOwnProperty("seq"))
+            if (!$util.isInteger(message.seq))
+                return "seq: integer expected";
+        if (message.chain != null && message.hasOwnProperty("chain")) {
+            if (!Array.isArray(message.chain))
+                return "chain: array expected";
+            for (let i = 0; i < message.chain.length; ++i) {
+                let error = $root.Link.verify(message.chain[i]);
+                if (error)
+                    return "chain." + error;
+            }
+        }
+        if (message.nonce != null && message.hasOwnProperty("nonce"))
+            if (!(message.nonce && typeof message.nonce.length === "number" || $util.isString(message.nonce)))
+                return "nonce: buffer expected";
+        if (message.box != null && message.hasOwnProperty("box"))
+            if (!(message.box && typeof message.box.length === "number" || $util.isString(message.box)))
+                return "box: buffer expected";
+        return null;
+    };
+
+    /**
+     * Creates a SyncRequest message from a plain object. Also converts values to their respective internal types.
+     * @function fromObject
+     * @memberof SyncRequest
+     * @static
+     * @param {Object.<string,*>} object Plain object
+     * @returns {SyncRequest} SyncRequest
+     */
+    SyncRequest.fromObject = function fromObject(object) {
+        if (object instanceof $root.SyncRequest)
+            return object;
+        let message = new $root.SyncRequest();
+        if (object.channelId != null)
+            if (typeof object.channelId === "string")
+                $util.base64.decode(object.channelId, message.channelId = $util.newBuffer($util.base64.length(object.channelId)), 0);
+            else if (object.channelId.length)
+                message.channelId = object.channelId;
+        if (object.seq != null)
+            message.seq = object.seq >>> 0;
+        if (object.chain) {
+            if (!Array.isArray(object.chain))
+                throw TypeError(".SyncRequest.chain: array expected");
+            message.chain = [];
+            for (let i = 0; i < object.chain.length; ++i) {
+                if (typeof object.chain[i] !== "object")
+                    throw TypeError(".SyncRequest.chain: object expected");
+                message.chain[i] = $root.Link.fromObject(object.chain[i]);
+            }
+        }
+        if (object.nonce != null)
+            if (typeof object.nonce === "string")
+                $util.base64.decode(object.nonce, message.nonce = $util.newBuffer($util.base64.length(object.nonce)), 0);
+            else if (object.nonce.length)
+                message.nonce = object.nonce;
+        if (object.box != null)
+            if (typeof object.box === "string")
+                $util.base64.decode(object.box, message.box = $util.newBuffer($util.base64.length(object.box)), 0);
+            else if (object.box.length)
+                message.box = object.box;
+        return message;
+    };
+
+    /**
+     * Creates a plain object from a SyncRequest message. Also converts values to other types if specified.
+     * @function toObject
+     * @memberof SyncRequest
+     * @static
+     * @param {SyncRequest} message SyncRequest
+     * @param {$protobuf.IConversionOptions} [options] Conversion options
+     * @returns {Object.<string,*>} Plain object
+     */
+    SyncRequest.toObject = function toObject(message, options) {
+        if (!options)
+            options = {};
+        let object = {};
+        if (options.arrays || options.defaults)
+            object.chain = [];
+        if (options.defaults) {
+            if (options.bytes === String)
+                object.channelId = "";
+            else {
+                object.channelId = [];
+                if (options.bytes !== Array)
+                    object.channelId = $util.newBuffer(object.channelId);
+            }
+            object.seq = 0;
+            if (options.bytes === String)
+                object.nonce = "";
+            else {
+                object.nonce = [];
+                if (options.bytes !== Array)
+                    object.nonce = $util.newBuffer(object.nonce);
+            }
+            if (options.bytes === String)
+                object.box = "";
+            else {
+                object.box = [];
+                if (options.bytes !== Array)
+                    object.box = $util.newBuffer(object.box);
+            }
+        }
+        if (message.channelId != null && message.hasOwnProperty("channelId"))
+            object.channelId = options.bytes === String ? $util.base64.encode(message.channelId, 0, message.channelId.length) : options.bytes === Array ? Array.prototype.slice.call(message.channelId) : message.channelId;
+        if (message.seq != null && message.hasOwnProperty("seq"))
+            object.seq = message.seq;
+        if (message.chain && message.chain.length) {
+            object.chain = [];
+            for (let j = 0; j < message.chain.length; ++j)
+                object.chain[j] = $root.Link.toObject(message.chain[j], options);
+        }
+        if (message.nonce != null && message.hasOwnProperty("nonce"))
+            object.nonce = options.bytes === String ? $util.base64.encode(message.nonce, 0, message.nonce.length) : options.bytes === Array ? Array.prototype.slice.call(message.nonce) : message.nonce;
+        if (message.box != null && message.hasOwnProperty("box"))
+            object.box = options.bytes === String ? $util.base64.encode(message.box, 0, message.box.length) : options.bytes === Array ? Array.prototype.slice.call(message.box) : message.box;
+        return object;
+    };
+
+    /**
+     * Converts this SyncRequest to JSON.
+     * @function toJSON
+     * @memberof SyncRequest
+     * @instance
+     * @returns {Object.<string,*>} JSON object
+     */
+    SyncRequest.prototype.toJSON = function toJSON() {
+        return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+    };
+
+    SyncRequest.Content = (function() {
+
+        /**
+         * Properties of a Content.
+         * @memberof SyncRequest
+         * @interface IContent
+         * @property {IQuery|null} [query] Content query
+         * @property {IBulk|null} [bulk] Content bulk
+         */
+
+        /**
+         * Constructs a new Content.
+         * @memberof SyncRequest
+         * @classdesc Represents a Content.
+         * @implements IContent
+         * @constructor
+         * @param {SyncRequest.IContent=} [properties] Properties to set
+         */
+        function Content(properties) {
+            if (properties)
+                for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                    if (properties[keys[i]] != null)
+                        this[keys[i]] = properties[keys[i]];
+        }
+
+        /**
+         * Content query.
+         * @member {IQuery|null|undefined} query
+         * @memberof SyncRequest.Content
+         * @instance
+         */
+        Content.prototype.query = null;
+
+        /**
+         * Content bulk.
+         * @member {IBulk|null|undefined} bulk
+         * @memberof SyncRequest.Content
+         * @instance
+         */
+        Content.prototype.bulk = null;
+
+        // OneOf field names bound to virtual getters and setters
+        let $oneOfFields;
+
+        /**
+         * Content content.
+         * @member {"query"|"bulk"|undefined} content
+         * @memberof SyncRequest.Content
+         * @instance
+         */
+        Object.defineProperty(Content.prototype, "content", {
+            get: $util.oneOfGetter($oneOfFields = ["query", "bulk"]),
+            set: $util.oneOfSetter($oneOfFields)
+        });
+
+        /**
+         * Creates a new Content instance using the specified properties.
+         * @function create
+         * @memberof SyncRequest.Content
+         * @static
+         * @param {SyncRequest.IContent=} [properties] Properties to set
+         * @returns {SyncRequest.Content} Content instance
+         */
+        Content.create = function create(properties) {
+            return new Content(properties);
+        };
+
+        /**
+         * Encodes the specified Content message. Does not implicitly {@link SyncRequest.Content.verify|verify} messages.
+         * @function encode
+         * @memberof SyncRequest.Content
+         * @static
+         * @param {SyncRequest.IContent} message Content message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        Content.encode = function encode(message, writer) {
+            if (!writer)
+                writer = $Writer.create();
+            if (message.query != null && message.hasOwnProperty("query"))
+                $root.Query.encode(message.query, writer.uint32(/* id 1, wireType 2 =*/10).fork()).ldelim();
+            if (message.bulk != null && message.hasOwnProperty("bulk"))
+                $root.Bulk.encode(message.bulk, writer.uint32(/* id 2, wireType 2 =*/18).fork()).ldelim();
+            return writer;
+        };
+
+        /**
+         * Encodes the specified Content message, length delimited. Does not implicitly {@link SyncRequest.Content.verify|verify} messages.
+         * @function encodeDelimited
+         * @memberof SyncRequest.Content
+         * @static
+         * @param {SyncRequest.IContent} message Content message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        Content.encodeDelimited = function encodeDelimited(message, writer) {
+            return this.encode(message, writer).ldelim();
+        };
+
+        /**
+         * Decodes a Content message from the specified reader or buffer.
+         * @function decode
+         * @memberof SyncRequest.Content
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @param {number} [length] Message length if known beforehand
+         * @returns {SyncRequest.Content} Content
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        Content.decode = function decode(reader, length) {
+            if (!(reader instanceof $Reader))
+                reader = $Reader.create(reader);
+            let end = length === undefined ? reader.len : reader.pos + length, message = new $root.SyncRequest.Content();
+            while (reader.pos < end) {
+                let tag = reader.uint32();
+                switch (tag >>> 3) {
+                case 1:
+                    message.query = $root.Query.decode(reader, reader.uint32());
+                    break;
+                case 2:
+                    message.bulk = $root.Bulk.decode(reader, reader.uint32());
+                    break;
+                default:
+                    reader.skipType(tag & 7);
+                    break;
+                }
+            }
+            return message;
+        };
+
+        /**
+         * Decodes a Content message from the specified reader or buffer, length delimited.
+         * @function decodeDelimited
+         * @memberof SyncRequest.Content
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @returns {SyncRequest.Content} Content
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        Content.decodeDelimited = function decodeDelimited(reader) {
+            if (!(reader instanceof $Reader))
+                reader = new $Reader(reader);
+            return this.decode(reader, reader.uint32());
+        };
+
+        /**
+         * Verifies a Content message.
+         * @function verify
+         * @memberof SyncRequest.Content
+         * @static
+         * @param {Object.<string,*>} message Plain object to verify
+         * @returns {string|null} `null` if valid, otherwise the reason why it is not
+         */
+        Content.verify = function verify(message) {
+            if (typeof message !== "object" || message === null)
+                return "object expected";
+            let properties = {};
+            if (message.query != null && message.hasOwnProperty("query")) {
+                properties.content = 1;
+                {
+                    let error = $root.Query.verify(message.query);
+                    if (error)
+                        return "query." + error;
+                }
+            }
+            if (message.bulk != null && message.hasOwnProperty("bulk")) {
+                if (properties.content === 1)
+                    return "content: multiple values";
+                properties.content = 1;
+                {
+                    let error = $root.Bulk.verify(message.bulk);
+                    if (error)
+                        return "bulk." + error;
+                }
+            }
+            return null;
+        };
+
+        /**
+         * Creates a Content message from a plain object. Also converts values to their respective internal types.
+         * @function fromObject
+         * @memberof SyncRequest.Content
+         * @static
+         * @param {Object.<string,*>} object Plain object
+         * @returns {SyncRequest.Content} Content
+         */
+        Content.fromObject = function fromObject(object) {
+            if (object instanceof $root.SyncRequest.Content)
+                return object;
+            let message = new $root.SyncRequest.Content();
+            if (object.query != null) {
+                if (typeof object.query !== "object")
+                    throw TypeError(".SyncRequest.Content.query: object expected");
+                message.query = $root.Query.fromObject(object.query);
+            }
+            if (object.bulk != null) {
+                if (typeof object.bulk !== "object")
+                    throw TypeError(".SyncRequest.Content.bulk: object expected");
+                message.bulk = $root.Bulk.fromObject(object.bulk);
+            }
+            return message;
+        };
+
+        /**
+         * Creates a plain object from a Content message. Also converts values to other types if specified.
+         * @function toObject
+         * @memberof SyncRequest.Content
+         * @static
+         * @param {SyncRequest.Content} message Content
+         * @param {$protobuf.IConversionOptions} [options] Conversion options
+         * @returns {Object.<string,*>} Plain object
+         */
+        Content.toObject = function toObject(message, options) {
+            if (!options)
+                options = {};
+            let object = {};
+            if (message.query != null && message.hasOwnProperty("query")) {
+                object.query = $root.Query.toObject(message.query, options);
+                if (options.oneofs)
+                    object.content = "query";
+            }
+            if (message.bulk != null && message.hasOwnProperty("bulk")) {
+                object.bulk = $root.Bulk.toObject(message.bulk, options);
+                if (options.oneofs)
+                    object.content = "bulk";
+            }
+            return object;
+        };
+
+        /**
+         * Converts this Content to JSON.
+         * @function toJSON
+         * @memberof SyncRequest.Content
+         * @instance
+         * @returns {Object.<string,*>} JSON object
+         */
+        Content.prototype.toJSON = function toJSON() {
+            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+        };
+
+        return Content;
+    })();
+
+    return SyncRequest;
+})();
+
+export const SyncResponse = $root.SyncResponse = (() => {
+
+    /**
+     * Properties of a SyncResponse.
+     * @exports ISyncResponse
+     * @interface ISyncResponse
+     * @property {Uint8Array|null} [channelId] SyncResponse channelId
+     * @property {number|null} [seq] SyncResponse seq
+     * @property {Uint8Array|null} [box] SyncResponse box
+     */
+
+    /**
+     * Constructs a new SyncResponse.
+     * @exports SyncResponse
+     * @classdesc Represents a SyncResponse.
+     * @implements ISyncResponse
+     * @constructor
+     * @param {ISyncResponse=} [properties] Properties to set
+     */
+    function SyncResponse(properties) {
+        if (properties)
+            for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                if (properties[keys[i]] != null)
+                    this[keys[i]] = properties[keys[i]];
+    }
+
+    /**
+     * SyncResponse channelId.
+     * @member {Uint8Array} channelId
+     * @memberof SyncResponse
+     * @instance
+     */
+    SyncResponse.prototype.channelId = $util.newBuffer([]);
+
+    /**
+     * SyncResponse seq.
+     * @member {number} seq
+     * @memberof SyncResponse
+     * @instance
+     */
+    SyncResponse.prototype.seq = 0;
+
+    /**
+     * SyncResponse box.
+     * @member {Uint8Array} box
+     * @memberof SyncResponse
+     * @instance
+     */
+    SyncResponse.prototype.box = $util.newBuffer([]);
+
+    /**
+     * Creates a new SyncResponse instance using the specified properties.
+     * @function create
+     * @memberof SyncResponse
+     * @static
+     * @param {ISyncResponse=} [properties] Properties to set
+     * @returns {SyncResponse} SyncResponse instance
+     */
+    SyncResponse.create = function create(properties) {
+        return new SyncResponse(properties);
+    };
+
+    /**
+     * Encodes the specified SyncResponse message. Does not implicitly {@link SyncResponse.verify|verify} messages.
+     * @function encode
+     * @memberof SyncResponse
+     * @static
+     * @param {ISyncResponse} message SyncResponse message or plain object to encode
+     * @param {$protobuf.Writer} [writer] Writer to encode to
+     * @returns {$protobuf.Writer} Writer
+     */
+    SyncResponse.encode = function encode(message, writer) {
+        if (!writer)
+            writer = $Writer.create();
+        if (message.channelId != null && message.hasOwnProperty("channelId"))
+            writer.uint32(/* id 1, wireType 2 =*/10).bytes(message.channelId);
+        if (message.seq != null && message.hasOwnProperty("seq"))
+            writer.uint32(/* id 2, wireType 0 =*/16).uint32(message.seq);
+        if (message.box != null && message.hasOwnProperty("box"))
+            writer.uint32(/* id 3, wireType 2 =*/26).bytes(message.box);
+        return writer;
+    };
+
+    /**
+     * Encodes the specified SyncResponse message, length delimited. Does not implicitly {@link SyncResponse.verify|verify} messages.
+     * @function encodeDelimited
+     * @memberof SyncResponse
+     * @static
+     * @param {ISyncResponse} message SyncResponse message or plain object to encode
+     * @param {$protobuf.Writer} [writer] Writer to encode to
+     * @returns {$protobuf.Writer} Writer
+     */
+    SyncResponse.encodeDelimited = function encodeDelimited(message, writer) {
+        return this.encode(message, writer).ldelim();
+    };
+
+    /**
+     * Decodes a SyncResponse message from the specified reader or buffer.
+     * @function decode
+     * @memberof SyncResponse
+     * @static
+     * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+     * @param {number} [length] Message length if known beforehand
+     * @returns {SyncResponse} SyncResponse
+     * @throws {Error} If the payload is not a reader or valid buffer
+     * @throws {$protobuf.util.ProtocolError} If required fields are missing
+     */
+    SyncResponse.decode = function decode(reader, length) {
+        if (!(reader instanceof $Reader))
+            reader = $Reader.create(reader);
+        let end = length === undefined ? reader.len : reader.pos + length, message = new $root.SyncResponse();
+        while (reader.pos < end) {
+            let tag = reader.uint32();
+            switch (tag >>> 3) {
+            case 1:
+                message.channelId = reader.bytes();
+                break;
+            case 2:
+                message.seq = reader.uint32();
+                break;
+            case 3:
+                message.box = reader.bytes();
+                break;
+            default:
+                reader.skipType(tag & 7);
+                break;
+            }
+        }
+        return message;
+    };
+
+    /**
+     * Decodes a SyncResponse message from the specified reader or buffer, length delimited.
+     * @function decodeDelimited
+     * @memberof SyncResponse
+     * @static
+     * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+     * @returns {SyncResponse} SyncResponse
+     * @throws {Error} If the payload is not a reader or valid buffer
+     * @throws {$protobuf.util.ProtocolError} If required fields are missing
+     */
+    SyncResponse.decodeDelimited = function decodeDelimited(reader) {
+        if (!(reader instanceof $Reader))
+            reader = new $Reader(reader);
+        return this.decode(reader, reader.uint32());
+    };
+
+    /**
+     * Verifies a SyncResponse message.
+     * @function verify
+     * @memberof SyncResponse
+     * @static
+     * @param {Object.<string,*>} message Plain object to verify
+     * @returns {string|null} `null` if valid, otherwise the reason why it is not
+     */
+    SyncResponse.verify = function verify(message) {
+        if (typeof message !== "object" || message === null)
+            return "object expected";
+        if (message.channelId != null && message.hasOwnProperty("channelId"))
+            if (!(message.channelId && typeof message.channelId.length === "number" || $util.isString(message.channelId)))
+                return "channelId: buffer expected";
+        if (message.seq != null && message.hasOwnProperty("seq"))
+            if (!$util.isInteger(message.seq))
+                return "seq: integer expected";
+        if (message.box != null && message.hasOwnProperty("box"))
+            if (!(message.box && typeof message.box.length === "number" || $util.isString(message.box)))
+                return "box: buffer expected";
+        return null;
+    };
+
+    /**
+     * Creates a SyncResponse message from a plain object. Also converts values to their respective internal types.
+     * @function fromObject
+     * @memberof SyncResponse
+     * @static
+     * @param {Object.<string,*>} object Plain object
+     * @returns {SyncResponse} SyncResponse
+     */
+    SyncResponse.fromObject = function fromObject(object) {
+        if (object instanceof $root.SyncResponse)
+            return object;
+        let message = new $root.SyncResponse();
+        if (object.channelId != null)
+            if (typeof object.channelId === "string")
+                $util.base64.decode(object.channelId, message.channelId = $util.newBuffer($util.base64.length(object.channelId)), 0);
+            else if (object.channelId.length)
+                message.channelId = object.channelId;
+        if (object.seq != null)
+            message.seq = object.seq >>> 0;
+        if (object.box != null)
+            if (typeof object.box === "string")
+                $util.base64.decode(object.box, message.box = $util.newBuffer($util.base64.length(object.box)), 0);
+            else if (object.box.length)
+                message.box = object.box;
+        return message;
+    };
+
+    /**
+     * Creates a plain object from a SyncResponse message. Also converts values to other types if specified.
+     * @function toObject
+     * @memberof SyncResponse
+     * @static
+     * @param {SyncResponse} message SyncResponse
+     * @param {$protobuf.IConversionOptions} [options] Conversion options
+     * @returns {Object.<string,*>} Plain object
+     */
+    SyncResponse.toObject = function toObject(message, options) {
+        if (!options)
+            options = {};
+        let object = {};
+        if (options.defaults) {
+            if (options.bytes === String)
+                object.channelId = "";
+            else {
+                object.channelId = [];
+                if (options.bytes !== Array)
+                    object.channelId = $util.newBuffer(object.channelId);
+            }
+            object.seq = 0;
+            if (options.bytes === String)
+                object.box = "";
+            else {
+                object.box = [];
+                if (options.bytes !== Array)
+                    object.box = $util.newBuffer(object.box);
+            }
+        }
+        if (message.channelId != null && message.hasOwnProperty("channelId"))
+            object.channelId = options.bytes === String ? $util.base64.encode(message.channelId, 0, message.channelId.length) : options.bytes === Array ? Array.prototype.slice.call(message.channelId) : message.channelId;
+        if (message.seq != null && message.hasOwnProperty("seq"))
+            object.seq = message.seq;
+        if (message.box != null && message.hasOwnProperty("box"))
+            object.box = options.bytes === String ? $util.base64.encode(message.box, 0, message.box.length) : options.bytes === Array ? Array.prototype.slice.call(message.box) : message.box;
+        return object;
+    };
+
+    /**
+     * Converts this SyncResponse to JSON.
+     * @function toJSON
+     * @memberof SyncResponse
+     * @instance
+     * @returns {Object.<string,*>} JSON object
+     */
+    SyncResponse.prototype.toJSON = function toJSON() {
+        return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+    };
+
+    SyncResponse.Content = (function() {
+
+        /**
+         * Properties of a Content.
+         * @memberof SyncResponse
+         * @interface IContent
+         * @property {IQueryResponse|null} [query] Content query
+         * @property {IBulkResponse|null} [bulk] Content bulk
+         */
+
+        /**
+         * Constructs a new Content.
+         * @memberof SyncResponse
+         * @classdesc Represents a Content.
+         * @implements IContent
+         * @constructor
+         * @param {SyncResponse.IContent=} [properties] Properties to set
+         */
+        function Content(properties) {
+            if (properties)
+                for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                    if (properties[keys[i]] != null)
+                        this[keys[i]] = properties[keys[i]];
+        }
+
+        /**
+         * Content query.
+         * @member {IQueryResponse|null|undefined} query
+         * @memberof SyncResponse.Content
+         * @instance
+         */
+        Content.prototype.query = null;
+
+        /**
+         * Content bulk.
+         * @member {IBulkResponse|null|undefined} bulk
+         * @memberof SyncResponse.Content
+         * @instance
+         */
+        Content.prototype.bulk = null;
+
+        // OneOf field names bound to virtual getters and setters
+        let $oneOfFields;
+
+        /**
+         * Content content.
+         * @member {"query"|"bulk"|undefined} content
+         * @memberof SyncResponse.Content
+         * @instance
+         */
+        Object.defineProperty(Content.prototype, "content", {
+            get: $util.oneOfGetter($oneOfFields = ["query", "bulk"]),
+            set: $util.oneOfSetter($oneOfFields)
+        });
+
+        /**
+         * Creates a new Content instance using the specified properties.
+         * @function create
+         * @memberof SyncResponse.Content
+         * @static
+         * @param {SyncResponse.IContent=} [properties] Properties to set
+         * @returns {SyncResponse.Content} Content instance
+         */
+        Content.create = function create(properties) {
+            return new Content(properties);
+        };
+
+        /**
+         * Encodes the specified Content message. Does not implicitly {@link SyncResponse.Content.verify|verify} messages.
+         * @function encode
+         * @memberof SyncResponse.Content
+         * @static
+         * @param {SyncResponse.IContent} message Content message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        Content.encode = function encode(message, writer) {
+            if (!writer)
+                writer = $Writer.create();
+            if (message.query != null && message.hasOwnProperty("query"))
+                $root.QueryResponse.encode(message.query, writer.uint32(/* id 1, wireType 2 =*/10).fork()).ldelim();
+            if (message.bulk != null && message.hasOwnProperty("bulk"))
+                $root.BulkResponse.encode(message.bulk, writer.uint32(/* id 2, wireType 2 =*/18).fork()).ldelim();
+            return writer;
+        };
+
+        /**
+         * Encodes the specified Content message, length delimited. Does not implicitly {@link SyncResponse.Content.verify|verify} messages.
+         * @function encodeDelimited
+         * @memberof SyncResponse.Content
+         * @static
+         * @param {SyncResponse.IContent} message Content message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        Content.encodeDelimited = function encodeDelimited(message, writer) {
+            return this.encode(message, writer).ldelim();
+        };
+
+        /**
+         * Decodes a Content message from the specified reader or buffer.
+         * @function decode
+         * @memberof SyncResponse.Content
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @param {number} [length] Message length if known beforehand
+         * @returns {SyncResponse.Content} Content
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        Content.decode = function decode(reader, length) {
+            if (!(reader instanceof $Reader))
+                reader = $Reader.create(reader);
+            let end = length === undefined ? reader.len : reader.pos + length, message = new $root.SyncResponse.Content();
+            while (reader.pos < end) {
+                let tag = reader.uint32();
+                switch (tag >>> 3) {
+                case 1:
+                    message.query = $root.QueryResponse.decode(reader, reader.uint32());
+                    break;
+                case 2:
+                    message.bulk = $root.BulkResponse.decode(reader, reader.uint32());
+                    break;
+                default:
+                    reader.skipType(tag & 7);
+                    break;
+                }
+            }
+            return message;
+        };
+
+        /**
+         * Decodes a Content message from the specified reader or buffer, length delimited.
+         * @function decodeDelimited
+         * @memberof SyncResponse.Content
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @returns {SyncResponse.Content} Content
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        Content.decodeDelimited = function decodeDelimited(reader) {
+            if (!(reader instanceof $Reader))
+                reader = new $Reader(reader);
+            return this.decode(reader, reader.uint32());
+        };
+
+        /**
+         * Verifies a Content message.
+         * @function verify
+         * @memberof SyncResponse.Content
+         * @static
+         * @param {Object.<string,*>} message Plain object to verify
+         * @returns {string|null} `null` if valid, otherwise the reason why it is not
+         */
+        Content.verify = function verify(message) {
+            if (typeof message !== "object" || message === null)
+                return "object expected";
+            let properties = {};
+            if (message.query != null && message.hasOwnProperty("query")) {
+                properties.content = 1;
+                {
+                    let error = $root.QueryResponse.verify(message.query);
+                    if (error)
+                        return "query." + error;
+                }
+            }
+            if (message.bulk != null && message.hasOwnProperty("bulk")) {
+                if (properties.content === 1)
+                    return "content: multiple values";
+                properties.content = 1;
+                {
+                    let error = $root.BulkResponse.verify(message.bulk);
+                    if (error)
+                        return "bulk." + error;
+                }
+            }
+            return null;
+        };
+
+        /**
+         * Creates a Content message from a plain object. Also converts values to their respective internal types.
+         * @function fromObject
+         * @memberof SyncResponse.Content
+         * @static
+         * @param {Object.<string,*>} object Plain object
+         * @returns {SyncResponse.Content} Content
+         */
+        Content.fromObject = function fromObject(object) {
+            if (object instanceof $root.SyncResponse.Content)
+                return object;
+            let message = new $root.SyncResponse.Content();
+            if (object.query != null) {
+                if (typeof object.query !== "object")
+                    throw TypeError(".SyncResponse.Content.query: object expected");
+                message.query = $root.QueryResponse.fromObject(object.query);
+            }
+            if (object.bulk != null) {
+                if (typeof object.bulk !== "object")
+                    throw TypeError(".SyncResponse.Content.bulk: object expected");
+                message.bulk = $root.BulkResponse.fromObject(object.bulk);
+            }
+            return message;
+        };
+
+        /**
+         * Creates a plain object from a Content message. Also converts values to other types if specified.
+         * @function toObject
+         * @memberof SyncResponse.Content
+         * @static
+         * @param {SyncResponse.Content} message Content
+         * @param {$protobuf.IConversionOptions} [options] Conversion options
+         * @returns {Object.<string,*>} Plain object
+         */
+        Content.toObject = function toObject(message, options) {
+            if (!options)
+                options = {};
+            let object = {};
+            if (message.query != null && message.hasOwnProperty("query")) {
+                object.query = $root.QueryResponse.toObject(message.query, options);
+                if (options.oneofs)
+                    object.content = "query";
+            }
+            if (message.bulk != null && message.hasOwnProperty("bulk")) {
+                object.bulk = $root.BulkResponse.toObject(message.bulk, options);
+                if (options.oneofs)
+                    object.content = "bulk";
+            }
+            return object;
+        };
+
+        /**
+         * Converts this Content to JSON.
+         * @function toJSON
+         * @memberof SyncResponse.Content
+         * @instance
+         * @returns {Object.<string,*>} JSON object
+         */
+        Content.prototype.toJSON = function toJSON() {
+            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+        };
+
+        return Content;
+    })();
+
+    return SyncResponse;
+})();
+
 export const Error = $root.Error = (() => {
 
     /**
@@ -4122,600 +5099,6 @@ export const Error = $root.Error = (() => {
     };
 
     return Error;
-})();
-
-export const ChannelPacket = $root.ChannelPacket = (() => {
-
-    /**
-     * Properties of a ChannelPacket.
-     * @exports IChannelPacket
-     * @interface IChannelPacket
-     * @property {Uint8Array|null} [channelId] ChannelPacket channelId
-     * @property {number|null} [seq] ChannelPacket seq
-     * @property {Uint8Array|null} [nonce] ChannelPacket nonce
-     * @property {Uint8Array|null} [box] ChannelPacket box
-     */
-
-    /**
-     * Constructs a new ChannelPacket.
-     * @exports ChannelPacket
-     * @classdesc Represents a ChannelPacket.
-     * @implements IChannelPacket
-     * @constructor
-     * @param {IChannelPacket=} [properties] Properties to set
-     */
-    function ChannelPacket(properties) {
-        if (properties)
-            for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-                if (properties[keys[i]] != null)
-                    this[keys[i]] = properties[keys[i]];
-    }
-
-    /**
-     * ChannelPacket channelId.
-     * @member {Uint8Array} channelId
-     * @memberof ChannelPacket
-     * @instance
-     */
-    ChannelPacket.prototype.channelId = $util.newBuffer([]);
-
-    /**
-     * ChannelPacket seq.
-     * @member {number} seq
-     * @memberof ChannelPacket
-     * @instance
-     */
-    ChannelPacket.prototype.seq = 0;
-
-    /**
-     * ChannelPacket nonce.
-     * @member {Uint8Array} nonce
-     * @memberof ChannelPacket
-     * @instance
-     */
-    ChannelPacket.prototype.nonce = $util.newBuffer([]);
-
-    /**
-     * ChannelPacket box.
-     * @member {Uint8Array} box
-     * @memberof ChannelPacket
-     * @instance
-     */
-    ChannelPacket.prototype.box = $util.newBuffer([]);
-
-    /**
-     * Creates a new ChannelPacket instance using the specified properties.
-     * @function create
-     * @memberof ChannelPacket
-     * @static
-     * @param {IChannelPacket=} [properties] Properties to set
-     * @returns {ChannelPacket} ChannelPacket instance
-     */
-    ChannelPacket.create = function create(properties) {
-        return new ChannelPacket(properties);
-    };
-
-    /**
-     * Encodes the specified ChannelPacket message. Does not implicitly {@link ChannelPacket.verify|verify} messages.
-     * @function encode
-     * @memberof ChannelPacket
-     * @static
-     * @param {IChannelPacket} message ChannelPacket message or plain object to encode
-     * @param {$protobuf.Writer} [writer] Writer to encode to
-     * @returns {$protobuf.Writer} Writer
-     */
-    ChannelPacket.encode = function encode(message, writer) {
-        if (!writer)
-            writer = $Writer.create();
-        if (message.channelId != null && message.hasOwnProperty("channelId"))
-            writer.uint32(/* id 1, wireType 2 =*/10).bytes(message.channelId);
-        if (message.seq != null && message.hasOwnProperty("seq"))
-            writer.uint32(/* id 2, wireType 0 =*/16).uint32(message.seq);
-        if (message.nonce != null && message.hasOwnProperty("nonce"))
-            writer.uint32(/* id 3, wireType 2 =*/26).bytes(message.nonce);
-        if (message.box != null && message.hasOwnProperty("box"))
-            writer.uint32(/* id 4, wireType 2 =*/34).bytes(message.box);
-        return writer;
-    };
-
-    /**
-     * Encodes the specified ChannelPacket message, length delimited. Does not implicitly {@link ChannelPacket.verify|verify} messages.
-     * @function encodeDelimited
-     * @memberof ChannelPacket
-     * @static
-     * @param {IChannelPacket} message ChannelPacket message or plain object to encode
-     * @param {$protobuf.Writer} [writer] Writer to encode to
-     * @returns {$protobuf.Writer} Writer
-     */
-    ChannelPacket.encodeDelimited = function encodeDelimited(message, writer) {
-        return this.encode(message, writer).ldelim();
-    };
-
-    /**
-     * Decodes a ChannelPacket message from the specified reader or buffer.
-     * @function decode
-     * @memberof ChannelPacket
-     * @static
-     * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
-     * @param {number} [length] Message length if known beforehand
-     * @returns {ChannelPacket} ChannelPacket
-     * @throws {Error} If the payload is not a reader or valid buffer
-     * @throws {$protobuf.util.ProtocolError} If required fields are missing
-     */
-    ChannelPacket.decode = function decode(reader, length) {
-        if (!(reader instanceof $Reader))
-            reader = $Reader.create(reader);
-        let end = length === undefined ? reader.len : reader.pos + length, message = new $root.ChannelPacket();
-        while (reader.pos < end) {
-            let tag = reader.uint32();
-            switch (tag >>> 3) {
-            case 1:
-                message.channelId = reader.bytes();
-                break;
-            case 2:
-                message.seq = reader.uint32();
-                break;
-            case 3:
-                message.nonce = reader.bytes();
-                break;
-            case 4:
-                message.box = reader.bytes();
-                break;
-            default:
-                reader.skipType(tag & 7);
-                break;
-            }
-        }
-        return message;
-    };
-
-    /**
-     * Decodes a ChannelPacket message from the specified reader or buffer, length delimited.
-     * @function decodeDelimited
-     * @memberof ChannelPacket
-     * @static
-     * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
-     * @returns {ChannelPacket} ChannelPacket
-     * @throws {Error} If the payload is not a reader or valid buffer
-     * @throws {$protobuf.util.ProtocolError} If required fields are missing
-     */
-    ChannelPacket.decodeDelimited = function decodeDelimited(reader) {
-        if (!(reader instanceof $Reader))
-            reader = new $Reader(reader);
-        return this.decode(reader, reader.uint32());
-    };
-
-    /**
-     * Verifies a ChannelPacket message.
-     * @function verify
-     * @memberof ChannelPacket
-     * @static
-     * @param {Object.<string,*>} message Plain object to verify
-     * @returns {string|null} `null` if valid, otherwise the reason why it is not
-     */
-    ChannelPacket.verify = function verify(message) {
-        if (typeof message !== "object" || message === null)
-            return "object expected";
-        if (message.channelId != null && message.hasOwnProperty("channelId"))
-            if (!(message.channelId && typeof message.channelId.length === "number" || $util.isString(message.channelId)))
-                return "channelId: buffer expected";
-        if (message.seq != null && message.hasOwnProperty("seq"))
-            if (!$util.isInteger(message.seq))
-                return "seq: integer expected";
-        if (message.nonce != null && message.hasOwnProperty("nonce"))
-            if (!(message.nonce && typeof message.nonce.length === "number" || $util.isString(message.nonce)))
-                return "nonce: buffer expected";
-        if (message.box != null && message.hasOwnProperty("box"))
-            if (!(message.box && typeof message.box.length === "number" || $util.isString(message.box)))
-                return "box: buffer expected";
-        return null;
-    };
-
-    /**
-     * Creates a ChannelPacket message from a plain object. Also converts values to their respective internal types.
-     * @function fromObject
-     * @memberof ChannelPacket
-     * @static
-     * @param {Object.<string,*>} object Plain object
-     * @returns {ChannelPacket} ChannelPacket
-     */
-    ChannelPacket.fromObject = function fromObject(object) {
-        if (object instanceof $root.ChannelPacket)
-            return object;
-        let message = new $root.ChannelPacket();
-        if (object.channelId != null)
-            if (typeof object.channelId === "string")
-                $util.base64.decode(object.channelId, message.channelId = $util.newBuffer($util.base64.length(object.channelId)), 0);
-            else if (object.channelId.length)
-                message.channelId = object.channelId;
-        if (object.seq != null)
-            message.seq = object.seq >>> 0;
-        if (object.nonce != null)
-            if (typeof object.nonce === "string")
-                $util.base64.decode(object.nonce, message.nonce = $util.newBuffer($util.base64.length(object.nonce)), 0);
-            else if (object.nonce.length)
-                message.nonce = object.nonce;
-        if (object.box != null)
-            if (typeof object.box === "string")
-                $util.base64.decode(object.box, message.box = $util.newBuffer($util.base64.length(object.box)), 0);
-            else if (object.box.length)
-                message.box = object.box;
-        return message;
-    };
-
-    /**
-     * Creates a plain object from a ChannelPacket message. Also converts values to other types if specified.
-     * @function toObject
-     * @memberof ChannelPacket
-     * @static
-     * @param {ChannelPacket} message ChannelPacket
-     * @param {$protobuf.IConversionOptions} [options] Conversion options
-     * @returns {Object.<string,*>} Plain object
-     */
-    ChannelPacket.toObject = function toObject(message, options) {
-        if (!options)
-            options = {};
-        let object = {};
-        if (options.defaults) {
-            if (options.bytes === String)
-                object.channelId = "";
-            else {
-                object.channelId = [];
-                if (options.bytes !== Array)
-                    object.channelId = $util.newBuffer(object.channelId);
-            }
-            object.seq = 0;
-            if (options.bytes === String)
-                object.nonce = "";
-            else {
-                object.nonce = [];
-                if (options.bytes !== Array)
-                    object.nonce = $util.newBuffer(object.nonce);
-            }
-            if (options.bytes === String)
-                object.box = "";
-            else {
-                object.box = [];
-                if (options.bytes !== Array)
-                    object.box = $util.newBuffer(object.box);
-            }
-        }
-        if (message.channelId != null && message.hasOwnProperty("channelId"))
-            object.channelId = options.bytes === String ? $util.base64.encode(message.channelId, 0, message.channelId.length) : options.bytes === Array ? Array.prototype.slice.call(message.channelId) : message.channelId;
-        if (message.seq != null && message.hasOwnProperty("seq"))
-            object.seq = message.seq;
-        if (message.nonce != null && message.hasOwnProperty("nonce"))
-            object.nonce = options.bytes === String ? $util.base64.encode(message.nonce, 0, message.nonce.length) : options.bytes === Array ? Array.prototype.slice.call(message.nonce) : message.nonce;
-        if (message.box != null && message.hasOwnProperty("box"))
-            object.box = options.bytes === String ? $util.base64.encode(message.box, 0, message.box.length) : options.bytes === Array ? Array.prototype.slice.call(message.box) : message.box;
-        return object;
-    };
-
-    /**
-     * Converts this ChannelPacket to JSON.
-     * @function toJSON
-     * @memberof ChannelPacket
-     * @instance
-     * @returns {Object.<string,*>} JSON object
-     */
-    ChannelPacket.prototype.toJSON = function toJSON() {
-        return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
-    };
-
-    ChannelPacket.Content = (function() {
-
-        /**
-         * Properties of a Content.
-         * @memberof ChannelPacket
-         * @interface IContent
-         * @property {IQuery|null} [query] Content query
-         * @property {IQueryResponse|null} [queryResponse] Content queryResponse
-         * @property {IBulk|null} [bulk] Content bulk
-         * @property {IBulkResponse|null} [bulkResponse] Content bulkResponse
-         */
-
-        /**
-         * Constructs a new Content.
-         * @memberof ChannelPacket
-         * @classdesc Represents a Content.
-         * @implements IContent
-         * @constructor
-         * @param {ChannelPacket.IContent=} [properties] Properties to set
-         */
-        function Content(properties) {
-            if (properties)
-                for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-                    if (properties[keys[i]] != null)
-                        this[keys[i]] = properties[keys[i]];
-        }
-
-        /**
-         * Content query.
-         * @member {IQuery|null|undefined} query
-         * @memberof ChannelPacket.Content
-         * @instance
-         */
-        Content.prototype.query = null;
-
-        /**
-         * Content queryResponse.
-         * @member {IQueryResponse|null|undefined} queryResponse
-         * @memberof ChannelPacket.Content
-         * @instance
-         */
-        Content.prototype.queryResponse = null;
-
-        /**
-         * Content bulk.
-         * @member {IBulk|null|undefined} bulk
-         * @memberof ChannelPacket.Content
-         * @instance
-         */
-        Content.prototype.bulk = null;
-
-        /**
-         * Content bulkResponse.
-         * @member {IBulkResponse|null|undefined} bulkResponse
-         * @memberof ChannelPacket.Content
-         * @instance
-         */
-        Content.prototype.bulkResponse = null;
-
-        // OneOf field names bound to virtual getters and setters
-        let $oneOfFields;
-
-        /**
-         * Content content.
-         * @member {"query"|"queryResponse"|"bulk"|"bulkResponse"|undefined} content
-         * @memberof ChannelPacket.Content
-         * @instance
-         */
-        Object.defineProperty(Content.prototype, "content", {
-            get: $util.oneOfGetter($oneOfFields = ["query", "queryResponse", "bulk", "bulkResponse"]),
-            set: $util.oneOfSetter($oneOfFields)
-        });
-
-        /**
-         * Creates a new Content instance using the specified properties.
-         * @function create
-         * @memberof ChannelPacket.Content
-         * @static
-         * @param {ChannelPacket.IContent=} [properties] Properties to set
-         * @returns {ChannelPacket.Content} Content instance
-         */
-        Content.create = function create(properties) {
-            return new Content(properties);
-        };
-
-        /**
-         * Encodes the specified Content message. Does not implicitly {@link ChannelPacket.Content.verify|verify} messages.
-         * @function encode
-         * @memberof ChannelPacket.Content
-         * @static
-         * @param {ChannelPacket.IContent} message Content message or plain object to encode
-         * @param {$protobuf.Writer} [writer] Writer to encode to
-         * @returns {$protobuf.Writer} Writer
-         */
-        Content.encode = function encode(message, writer) {
-            if (!writer)
-                writer = $Writer.create();
-            if (message.query != null && message.hasOwnProperty("query"))
-                $root.Query.encode(message.query, writer.uint32(/* id 1, wireType 2 =*/10).fork()).ldelim();
-            if (message.queryResponse != null && message.hasOwnProperty("queryResponse"))
-                $root.QueryResponse.encode(message.queryResponse, writer.uint32(/* id 2, wireType 2 =*/18).fork()).ldelim();
-            if (message.bulk != null && message.hasOwnProperty("bulk"))
-                $root.Bulk.encode(message.bulk, writer.uint32(/* id 3, wireType 2 =*/26).fork()).ldelim();
-            if (message.bulkResponse != null && message.hasOwnProperty("bulkResponse"))
-                $root.BulkResponse.encode(message.bulkResponse, writer.uint32(/* id 4, wireType 2 =*/34).fork()).ldelim();
-            return writer;
-        };
-
-        /**
-         * Encodes the specified Content message, length delimited. Does not implicitly {@link ChannelPacket.Content.verify|verify} messages.
-         * @function encodeDelimited
-         * @memberof ChannelPacket.Content
-         * @static
-         * @param {ChannelPacket.IContent} message Content message or plain object to encode
-         * @param {$protobuf.Writer} [writer] Writer to encode to
-         * @returns {$protobuf.Writer} Writer
-         */
-        Content.encodeDelimited = function encodeDelimited(message, writer) {
-            return this.encode(message, writer).ldelim();
-        };
-
-        /**
-         * Decodes a Content message from the specified reader or buffer.
-         * @function decode
-         * @memberof ChannelPacket.Content
-         * @static
-         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
-         * @param {number} [length] Message length if known beforehand
-         * @returns {ChannelPacket.Content} Content
-         * @throws {Error} If the payload is not a reader or valid buffer
-         * @throws {$protobuf.util.ProtocolError} If required fields are missing
-         */
-        Content.decode = function decode(reader, length) {
-            if (!(reader instanceof $Reader))
-                reader = $Reader.create(reader);
-            let end = length === undefined ? reader.len : reader.pos + length, message = new $root.ChannelPacket.Content();
-            while (reader.pos < end) {
-                let tag = reader.uint32();
-                switch (tag >>> 3) {
-                case 1:
-                    message.query = $root.Query.decode(reader, reader.uint32());
-                    break;
-                case 2:
-                    message.queryResponse = $root.QueryResponse.decode(reader, reader.uint32());
-                    break;
-                case 3:
-                    message.bulk = $root.Bulk.decode(reader, reader.uint32());
-                    break;
-                case 4:
-                    message.bulkResponse = $root.BulkResponse.decode(reader, reader.uint32());
-                    break;
-                default:
-                    reader.skipType(tag & 7);
-                    break;
-                }
-            }
-            return message;
-        };
-
-        /**
-         * Decodes a Content message from the specified reader or buffer, length delimited.
-         * @function decodeDelimited
-         * @memberof ChannelPacket.Content
-         * @static
-         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
-         * @returns {ChannelPacket.Content} Content
-         * @throws {Error} If the payload is not a reader or valid buffer
-         * @throws {$protobuf.util.ProtocolError} If required fields are missing
-         */
-        Content.decodeDelimited = function decodeDelimited(reader) {
-            if (!(reader instanceof $Reader))
-                reader = new $Reader(reader);
-            return this.decode(reader, reader.uint32());
-        };
-
-        /**
-         * Verifies a Content message.
-         * @function verify
-         * @memberof ChannelPacket.Content
-         * @static
-         * @param {Object.<string,*>} message Plain object to verify
-         * @returns {string|null} `null` if valid, otherwise the reason why it is not
-         */
-        Content.verify = function verify(message) {
-            if (typeof message !== "object" || message === null)
-                return "object expected";
-            let properties = {};
-            if (message.query != null && message.hasOwnProperty("query")) {
-                properties.content = 1;
-                {
-                    let error = $root.Query.verify(message.query);
-                    if (error)
-                        return "query." + error;
-                }
-            }
-            if (message.queryResponse != null && message.hasOwnProperty("queryResponse")) {
-                if (properties.content === 1)
-                    return "content: multiple values";
-                properties.content = 1;
-                {
-                    let error = $root.QueryResponse.verify(message.queryResponse);
-                    if (error)
-                        return "queryResponse." + error;
-                }
-            }
-            if (message.bulk != null && message.hasOwnProperty("bulk")) {
-                if (properties.content === 1)
-                    return "content: multiple values";
-                properties.content = 1;
-                {
-                    let error = $root.Bulk.verify(message.bulk);
-                    if (error)
-                        return "bulk." + error;
-                }
-            }
-            if (message.bulkResponse != null && message.hasOwnProperty("bulkResponse")) {
-                if (properties.content === 1)
-                    return "content: multiple values";
-                properties.content = 1;
-                {
-                    let error = $root.BulkResponse.verify(message.bulkResponse);
-                    if (error)
-                        return "bulkResponse." + error;
-                }
-            }
-            return null;
-        };
-
-        /**
-         * Creates a Content message from a plain object. Also converts values to their respective internal types.
-         * @function fromObject
-         * @memberof ChannelPacket.Content
-         * @static
-         * @param {Object.<string,*>} object Plain object
-         * @returns {ChannelPacket.Content} Content
-         */
-        Content.fromObject = function fromObject(object) {
-            if (object instanceof $root.ChannelPacket.Content)
-                return object;
-            let message = new $root.ChannelPacket.Content();
-            if (object.query != null) {
-                if (typeof object.query !== "object")
-                    throw TypeError(".ChannelPacket.Content.query: object expected");
-                message.query = $root.Query.fromObject(object.query);
-            }
-            if (object.queryResponse != null) {
-                if (typeof object.queryResponse !== "object")
-                    throw TypeError(".ChannelPacket.Content.queryResponse: object expected");
-                message.queryResponse = $root.QueryResponse.fromObject(object.queryResponse);
-            }
-            if (object.bulk != null) {
-                if (typeof object.bulk !== "object")
-                    throw TypeError(".ChannelPacket.Content.bulk: object expected");
-                message.bulk = $root.Bulk.fromObject(object.bulk);
-            }
-            if (object.bulkResponse != null) {
-                if (typeof object.bulkResponse !== "object")
-                    throw TypeError(".ChannelPacket.Content.bulkResponse: object expected");
-                message.bulkResponse = $root.BulkResponse.fromObject(object.bulkResponse);
-            }
-            return message;
-        };
-
-        /**
-         * Creates a plain object from a Content message. Also converts values to other types if specified.
-         * @function toObject
-         * @memberof ChannelPacket.Content
-         * @static
-         * @param {ChannelPacket.Content} message Content
-         * @param {$protobuf.IConversionOptions} [options] Conversion options
-         * @returns {Object.<string,*>} Plain object
-         */
-        Content.toObject = function toObject(message, options) {
-            if (!options)
-                options = {};
-            let object = {};
-            if (message.query != null && message.hasOwnProperty("query")) {
-                object.query = $root.Query.toObject(message.query, options);
-                if (options.oneofs)
-                    object.content = "query";
-            }
-            if (message.queryResponse != null && message.hasOwnProperty("queryResponse")) {
-                object.queryResponse = $root.QueryResponse.toObject(message.queryResponse, options);
-                if (options.oneofs)
-                    object.content = "queryResponse";
-            }
-            if (message.bulk != null && message.hasOwnProperty("bulk")) {
-                object.bulk = $root.Bulk.toObject(message.bulk, options);
-                if (options.oneofs)
-                    object.content = "bulk";
-            }
-            if (message.bulkResponse != null && message.hasOwnProperty("bulkResponse")) {
-                object.bulkResponse = $root.BulkResponse.toObject(message.bulkResponse, options);
-                if (options.oneofs)
-                    object.content = "bulkResponse";
-            }
-            return object;
-        };
-
-        /**
-         * Converts this Content to JSON.
-         * @function toJSON
-         * @memberof ChannelPacket.Content
-         * @instance
-         * @returns {Object.<string,*>} JSON object
-         */
-        Content.prototype.toJSON = function toJSON() {
-            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
-        };
-
-        return Content;
-    })();
-
-    return ChannelPacket;
 })();
 
 export const Notification = $root.Notification = (() => {
@@ -4922,7 +5305,8 @@ export const Packet = $root.Packet = (() => {
      * @interface IPacket
      * @property {IError|null} [error] Packet error
      * @property {IEncryptedInvite|null} [invite] Packet invite
-     * @property {IChannelPacket|null} [channelPacket] Packet channelPacket
+     * @property {ISyncRequest|null} [syncRequest] Packet syncRequest
+     * @property {ISyncResponse|null} [syncResponse] Packet syncResponse
      * @property {INotification|null} [notification] Packet notification
      */
 
@@ -4958,12 +5342,20 @@ export const Packet = $root.Packet = (() => {
     Packet.prototype.invite = null;
 
     /**
-     * Packet channelPacket.
-     * @member {IChannelPacket|null|undefined} channelPacket
+     * Packet syncRequest.
+     * @member {ISyncRequest|null|undefined} syncRequest
      * @memberof Packet
      * @instance
      */
-    Packet.prototype.channelPacket = null;
+    Packet.prototype.syncRequest = null;
+
+    /**
+     * Packet syncResponse.
+     * @member {ISyncResponse|null|undefined} syncResponse
+     * @memberof Packet
+     * @instance
+     */
+    Packet.prototype.syncResponse = null;
 
     /**
      * Packet notification.
@@ -4978,12 +5370,12 @@ export const Packet = $root.Packet = (() => {
 
     /**
      * Packet content.
-     * @member {"error"|"invite"|"channelPacket"|"notification"|undefined} content
+     * @member {"error"|"invite"|"syncRequest"|"syncResponse"|"notification"|undefined} content
      * @memberof Packet
      * @instance
      */
     Object.defineProperty(Packet.prototype, "content", {
-        get: $util.oneOfGetter($oneOfFields = ["error", "invite", "channelPacket", "notification"]),
+        get: $util.oneOfGetter($oneOfFields = ["error", "invite", "syncRequest", "syncResponse", "notification"]),
         set: $util.oneOfSetter($oneOfFields)
     });
 
@@ -5015,10 +5407,12 @@ export const Packet = $root.Packet = (() => {
             $root.Error.encode(message.error, writer.uint32(/* id 1, wireType 2 =*/10).fork()).ldelim();
         if (message.invite != null && message.hasOwnProperty("invite"))
             $root.EncryptedInvite.encode(message.invite, writer.uint32(/* id 2, wireType 2 =*/18).fork()).ldelim();
-        if (message.channelPacket != null && message.hasOwnProperty("channelPacket"))
-            $root.ChannelPacket.encode(message.channelPacket, writer.uint32(/* id 3, wireType 2 =*/26).fork()).ldelim();
+        if (message.syncRequest != null && message.hasOwnProperty("syncRequest"))
+            $root.SyncRequest.encode(message.syncRequest, writer.uint32(/* id 3, wireType 2 =*/26).fork()).ldelim();
+        if (message.syncResponse != null && message.hasOwnProperty("syncResponse"))
+            $root.SyncResponse.encode(message.syncResponse, writer.uint32(/* id 4, wireType 2 =*/34).fork()).ldelim();
         if (message.notification != null && message.hasOwnProperty("notification"))
-            $root.Notification.encode(message.notification, writer.uint32(/* id 4, wireType 2 =*/34).fork()).ldelim();
+            $root.Notification.encode(message.notification, writer.uint32(/* id 5, wireType 2 =*/42).fork()).ldelim();
         return writer;
     };
 
@@ -5060,9 +5454,12 @@ export const Packet = $root.Packet = (() => {
                 message.invite = $root.EncryptedInvite.decode(reader, reader.uint32());
                 break;
             case 3:
-                message.channelPacket = $root.ChannelPacket.decode(reader, reader.uint32());
+                message.syncRequest = $root.SyncRequest.decode(reader, reader.uint32());
                 break;
             case 4:
+                message.syncResponse = $root.SyncResponse.decode(reader, reader.uint32());
+                break;
+            case 5:
                 message.notification = $root.Notification.decode(reader, reader.uint32());
                 break;
             default:
@@ -5119,14 +5516,24 @@ export const Packet = $root.Packet = (() => {
                     return "invite." + error;
             }
         }
-        if (message.channelPacket != null && message.hasOwnProperty("channelPacket")) {
+        if (message.syncRequest != null && message.hasOwnProperty("syncRequest")) {
             if (properties.content === 1)
                 return "content: multiple values";
             properties.content = 1;
             {
-                let error = $root.ChannelPacket.verify(message.channelPacket);
+                let error = $root.SyncRequest.verify(message.syncRequest);
                 if (error)
-                    return "channelPacket." + error;
+                    return "syncRequest." + error;
+            }
+        }
+        if (message.syncResponse != null && message.hasOwnProperty("syncResponse")) {
+            if (properties.content === 1)
+                return "content: multiple values";
+            properties.content = 1;
+            {
+                let error = $root.SyncResponse.verify(message.syncResponse);
+                if (error)
+                    return "syncResponse." + error;
             }
         }
         if (message.notification != null && message.hasOwnProperty("notification")) {
@@ -5164,10 +5571,15 @@ export const Packet = $root.Packet = (() => {
                 throw TypeError(".Packet.invite: object expected");
             message.invite = $root.EncryptedInvite.fromObject(object.invite);
         }
-        if (object.channelPacket != null) {
-            if (typeof object.channelPacket !== "object")
-                throw TypeError(".Packet.channelPacket: object expected");
-            message.channelPacket = $root.ChannelPacket.fromObject(object.channelPacket);
+        if (object.syncRequest != null) {
+            if (typeof object.syncRequest !== "object")
+                throw TypeError(".Packet.syncRequest: object expected");
+            message.syncRequest = $root.SyncRequest.fromObject(object.syncRequest);
+        }
+        if (object.syncResponse != null) {
+            if (typeof object.syncResponse !== "object")
+                throw TypeError(".Packet.syncResponse: object expected");
+            message.syncResponse = $root.SyncResponse.fromObject(object.syncResponse);
         }
         if (object.notification != null) {
             if (typeof object.notification !== "object")
@@ -5200,10 +5612,15 @@ export const Packet = $root.Packet = (() => {
             if (options.oneofs)
                 object.content = "invite";
         }
-        if (message.channelPacket != null && message.hasOwnProperty("channelPacket")) {
-            object.channelPacket = $root.ChannelPacket.toObject(message.channelPacket, options);
+        if (message.syncRequest != null && message.hasOwnProperty("syncRequest")) {
+            object.syncRequest = $root.SyncRequest.toObject(message.syncRequest, options);
             if (options.oneofs)
-                object.content = "channelPacket";
+                object.content = "syncRequest";
+        }
+        if (message.syncResponse != null && message.hasOwnProperty("syncResponse")) {
+            object.syncResponse = $root.SyncResponse.toObject(message.syncResponse, options);
+            if (options.oneofs)
+                object.content = "syncResponse";
         }
         if (message.notification != null && message.hasOwnProperty("notification")) {
             object.notification = $root.Notification.toObject(message.notification, options);

--- a/lib/messages.js
+++ b/lib/messages.js
@@ -2616,6 +2616,7 @@ export const Query = $root.Query = (() => {
      * Properties of a Query.
      * @exports IQuery
      * @interface IQuery
+     * @property {Array.<ILink>|null} [chain] Query chain
      * @property {number|Long|null} [height] Query height
      * @property {Uint8Array|null} [hash] Query hash
      * @property {boolean|null} [isBackward] Query isBackward
@@ -2631,11 +2632,20 @@ export const Query = $root.Query = (() => {
      * @param {IQuery=} [properties] Properties to set
      */
     function Query(properties) {
+        this.chain = [];
         if (properties)
             for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
                 if (properties[keys[i]] != null)
                     this[keys[i]] = properties[keys[i]];
     }
+
+    /**
+     * Query chain.
+     * @member {Array.<ILink>} chain
+     * @memberof Query
+     * @instance
+     */
+    Query.prototype.chain = $util.emptyArray;
 
     /**
      * Query height.
@@ -2707,14 +2717,17 @@ export const Query = $root.Query = (() => {
     Query.encode = function encode(message, writer) {
         if (!writer)
             writer = $Writer.create();
+        if (message.chain != null && message.chain.length)
+            for (let i = 0; i < message.chain.length; ++i)
+                $root.Link.encode(message.chain[i], writer.uint32(/* id 1, wireType 2 =*/10).fork()).ldelim();
         if (message.height != null && message.hasOwnProperty("height"))
-            writer.uint32(/* id 1, wireType 0 =*/8).int64(message.height);
+            writer.uint32(/* id 2, wireType 0 =*/16).int64(message.height);
         if (message.hash != null && message.hasOwnProperty("hash"))
-            writer.uint32(/* id 2, wireType 2 =*/18).bytes(message.hash);
+            writer.uint32(/* id 3, wireType 2 =*/26).bytes(message.hash);
         if (message.isBackward != null && message.hasOwnProperty("isBackward"))
-            writer.uint32(/* id 3, wireType 0 =*/24).bool(message.isBackward);
+            writer.uint32(/* id 4, wireType 0 =*/32).bool(message.isBackward);
         if (message.limit != null && message.hasOwnProperty("limit"))
-            writer.uint32(/* id 4, wireType 0 =*/32).uint32(message.limit);
+            writer.uint32(/* id 5, wireType 0 =*/40).uint32(message.limit);
         return writer;
     };
 
@@ -2750,15 +2763,20 @@ export const Query = $root.Query = (() => {
             let tag = reader.uint32();
             switch (tag >>> 3) {
             case 1:
-                message.height = reader.int64();
+                if (!(message.chain && message.chain.length))
+                    message.chain = [];
+                message.chain.push($root.Link.decode(reader, reader.uint32()));
                 break;
             case 2:
-                message.hash = reader.bytes();
+                message.height = reader.int64();
                 break;
             case 3:
-                message.isBackward = reader.bool();
+                message.hash = reader.bytes();
                 break;
             case 4:
+                message.isBackward = reader.bool();
+                break;
+            case 5:
                 message.limit = reader.uint32();
                 break;
             default:
@@ -2797,6 +2815,15 @@ export const Query = $root.Query = (() => {
         if (typeof message !== "object" || message === null)
             return "object expected";
         let properties = {};
+        if (message.chain != null && message.hasOwnProperty("chain")) {
+            if (!Array.isArray(message.chain))
+                return "chain: array expected";
+            for (let i = 0; i < message.chain.length; ++i) {
+                let error = $root.Link.verify(message.chain[i]);
+                if (error)
+                    return "chain." + error;
+            }
+        }
         if (message.height != null && message.hasOwnProperty("height")) {
             properties.cursor = 1;
             if (!$util.isInteger(message.height) && !(message.height && $util.isInteger(message.height.low) && $util.isInteger(message.height.high)))
@@ -2830,6 +2857,16 @@ export const Query = $root.Query = (() => {
         if (object instanceof $root.Query)
             return object;
         let message = new $root.Query();
+        if (object.chain) {
+            if (!Array.isArray(object.chain))
+                throw TypeError(".Query.chain: array expected");
+            message.chain = [];
+            for (let i = 0; i < object.chain.length; ++i) {
+                if (typeof object.chain[i] !== "object")
+                    throw TypeError(".Query.chain: object expected");
+                message.chain[i] = $root.Link.fromObject(object.chain[i]);
+            }
+        }
         if (object.height != null)
             if ($util.Long)
                 (message.height = $util.Long.fromValue(object.height)).unsigned = false;
@@ -2864,9 +2901,16 @@ export const Query = $root.Query = (() => {
         if (!options)
             options = {};
         let object = {};
+        if (options.arrays || options.defaults)
+            object.chain = [];
         if (options.defaults) {
             object.isBackward = false;
             object.limit = 0;
+        }
+        if (message.chain && message.chain.length) {
+            object.chain = [];
+            for (let j = 0; j < message.chain.length; ++j)
+                object.chain[j] = $root.Link.toObject(message.chain[j], options);
         }
         if (message.height != null && message.hasOwnProperty("height")) {
             if (typeof message.height === "number")
@@ -3418,6 +3462,7 @@ export const Bulk = $root.Bulk = (() => {
      * Properties of a Bulk.
      * @exports IBulk
      * @interface IBulk
+     * @property {Array.<ILink>|null} [chain] Bulk chain
      * @property {Array.<Uint8Array>|null} [hashes] Bulk hashes
      */
 
@@ -3430,12 +3475,21 @@ export const Bulk = $root.Bulk = (() => {
      * @param {IBulk=} [properties] Properties to set
      */
     function Bulk(properties) {
+        this.chain = [];
         this.hashes = [];
         if (properties)
             for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
                 if (properties[keys[i]] != null)
                     this[keys[i]] = properties[keys[i]];
     }
+
+    /**
+     * Bulk chain.
+     * @member {Array.<ILink>} chain
+     * @memberof Bulk
+     * @instance
+     */
+    Bulk.prototype.chain = $util.emptyArray;
 
     /**
      * Bulk hashes.
@@ -3469,9 +3523,12 @@ export const Bulk = $root.Bulk = (() => {
     Bulk.encode = function encode(message, writer) {
         if (!writer)
             writer = $Writer.create();
+        if (message.chain != null && message.chain.length)
+            for (let i = 0; i < message.chain.length; ++i)
+                $root.Link.encode(message.chain[i], writer.uint32(/* id 1, wireType 2 =*/10).fork()).ldelim();
         if (message.hashes != null && message.hashes.length)
             for (let i = 0; i < message.hashes.length; ++i)
-                writer.uint32(/* id 1, wireType 2 =*/10).bytes(message.hashes[i]);
+                writer.uint32(/* id 2, wireType 2 =*/18).bytes(message.hashes[i]);
         return writer;
     };
 
@@ -3507,6 +3564,11 @@ export const Bulk = $root.Bulk = (() => {
             let tag = reader.uint32();
             switch (tag >>> 3) {
             case 1:
+                if (!(message.chain && message.chain.length))
+                    message.chain = [];
+                message.chain.push($root.Link.decode(reader, reader.uint32()));
+                break;
+            case 2:
                 if (!(message.hashes && message.hashes.length))
                     message.hashes = [];
                 message.hashes.push(reader.bytes());
@@ -3546,6 +3608,15 @@ export const Bulk = $root.Bulk = (() => {
     Bulk.verify = function verify(message) {
         if (typeof message !== "object" || message === null)
             return "object expected";
+        if (message.chain != null && message.hasOwnProperty("chain")) {
+            if (!Array.isArray(message.chain))
+                return "chain: array expected";
+            for (let i = 0; i < message.chain.length; ++i) {
+                let error = $root.Link.verify(message.chain[i]);
+                if (error)
+                    return "chain." + error;
+            }
+        }
         if (message.hashes != null && message.hasOwnProperty("hashes")) {
             if (!Array.isArray(message.hashes))
                 return "hashes: array expected";
@@ -3568,6 +3639,16 @@ export const Bulk = $root.Bulk = (() => {
         if (object instanceof $root.Bulk)
             return object;
         let message = new $root.Bulk();
+        if (object.chain) {
+            if (!Array.isArray(object.chain))
+                throw TypeError(".Bulk.chain: array expected");
+            message.chain = [];
+            for (let i = 0; i < object.chain.length; ++i) {
+                if (typeof object.chain[i] !== "object")
+                    throw TypeError(".Bulk.chain: object expected");
+                message.chain[i] = $root.Link.fromObject(object.chain[i]);
+            }
+        }
         if (object.hashes) {
             if (!Array.isArray(object.hashes))
                 throw TypeError(".Bulk.hashes: array expected");
@@ -3594,8 +3675,15 @@ export const Bulk = $root.Bulk = (() => {
         if (!options)
             options = {};
         let object = {};
-        if (options.arrays || options.defaults)
+        if (options.arrays || options.defaults) {
+            object.chain = [];
             object.hashes = [];
+        }
+        if (message.chain && message.chain.length) {
+            object.chain = [];
+            for (let j = 0; j < message.chain.length; ++j)
+                object.chain[j] = $root.Link.toObject(message.chain[j], options);
+        }
         if (message.hashes && message.hashes.length) {
             object.hashes = [];
             for (let j = 0; j < message.hashes.length; ++j)

--- a/lib/messages.js
+++ b/lib/messages.js
@@ -731,11 +731,11 @@ export const Link = $root.Link = (() => {
             if (message.trusteeDisplayName != null && message.hasOwnProperty("trusteeDisplayName"))
                 writer.uint32(/* id 2, wireType 2 =*/18).string(message.trusteeDisplayName);
             if (message.validFrom != null && message.hasOwnProperty("validFrom"))
-                writer.uint32(/* id 4, wireType 1 =*/33).double(message.validFrom);
+                writer.uint32(/* id 3, wireType 1 =*/25).double(message.validFrom);
             if (message.validTo != null && message.hasOwnProperty("validTo"))
-                writer.uint32(/* id 5, wireType 1 =*/41).double(message.validTo);
+                writer.uint32(/* id 4, wireType 1 =*/33).double(message.validTo);
             if (message.channelId != null && message.hasOwnProperty("channelId"))
-                writer.uint32(/* id 6, wireType 2 =*/50).bytes(message.channelId);
+                writer.uint32(/* id 5, wireType 2 =*/42).bytes(message.channelId);
             return writer;
         };
 
@@ -776,13 +776,13 @@ export const Link = $root.Link = (() => {
                 case 2:
                     message.trusteeDisplayName = reader.string();
                     break;
-                case 4:
+                case 3:
                     message.validFrom = reader.double();
                     break;
-                case 5:
+                case 4:
                     message.validTo = reader.double();
                     break;
-                case 6:
+                case 5:
                     message.channelId = reader.bytes();
                     break;
                 default:
@@ -1012,7 +1012,7 @@ export const Invite = $root.Invite = (() => {
             writer.uint32(/* id 2, wireType 2 =*/18).string(message.channelName);
         if (message.chain != null && message.chain.length)
             for (let i = 0; i < message.chain.length; ++i)
-                $root.Link.encode(message.chain[i], writer.uint32(/* id 4, wireType 2 =*/34).fork()).ldelim();
+                $root.Link.encode(message.chain[i], writer.uint32(/* id 3, wireType 2 =*/26).fork()).ldelim();
         return writer;
     };
 
@@ -1053,7 +1053,7 @@ export const Invite = $root.Invite = (() => {
             case 2:
                 message.channelName = reader.string();
                 break;
-            case 4:
+            case 3:
                 if (!(message.chain && message.chain.length))
                     message.chain = [];
                 message.chain.push($root.Link.decode(reader, reader.uint32()));
@@ -1656,9 +1656,6 @@ export const ChannelMessage = $root.ChannelMessage = (() => {
      * Properties of a ChannelMessage.
      * @exports IChannelMessage
      * @interface IChannelMessage
-     * @property {Uint8Array|null} [channelId] ChannelMessage channelId
-     * @property {Array.<Uint8Array>|null} [parents] ChannelMessage parents
-     * @property {number|Long|null} [height] ChannelMessage height
      * @property {Uint8Array|null} [nonce] ChannelMessage nonce
      * @property {Uint8Array|null} [encryptedContent] ChannelMessage encryptedContent
      */
@@ -1672,36 +1669,11 @@ export const ChannelMessage = $root.ChannelMessage = (() => {
      * @param {IChannelMessage=} [properties] Properties to set
      */
     function ChannelMessage(properties) {
-        this.parents = [];
         if (properties)
             for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
                 if (properties[keys[i]] != null)
                     this[keys[i]] = properties[keys[i]];
     }
-
-    /**
-     * ChannelMessage channelId.
-     * @member {Uint8Array} channelId
-     * @memberof ChannelMessage
-     * @instance
-     */
-    ChannelMessage.prototype.channelId = $util.newBuffer([]);
-
-    /**
-     * ChannelMessage parents.
-     * @member {Array.<Uint8Array>} parents
-     * @memberof ChannelMessage
-     * @instance
-     */
-    ChannelMessage.prototype.parents = $util.emptyArray;
-
-    /**
-     * ChannelMessage height.
-     * @member {number|Long} height
-     * @memberof ChannelMessage
-     * @instance
-     */
-    ChannelMessage.prototype.height = $util.Long ? $util.Long.fromBits(0,0,false) : 0;
 
     /**
      * ChannelMessage nonce.
@@ -1743,17 +1715,10 @@ export const ChannelMessage = $root.ChannelMessage = (() => {
     ChannelMessage.encode = function encode(message, writer) {
         if (!writer)
             writer = $Writer.create();
-        if (message.channelId != null && message.hasOwnProperty("channelId"))
-            writer.uint32(/* id 1, wireType 2 =*/10).bytes(message.channelId);
-        if (message.parents != null && message.parents.length)
-            for (let i = 0; i < message.parents.length; ++i)
-                writer.uint32(/* id 2, wireType 2 =*/18).bytes(message.parents[i]);
-        if (message.height != null && message.hasOwnProperty("height"))
-            writer.uint32(/* id 3, wireType 0 =*/24).int64(message.height);
         if (message.nonce != null && message.hasOwnProperty("nonce"))
-            writer.uint32(/* id 4, wireType 2 =*/34).bytes(message.nonce);
+            writer.uint32(/* id 1, wireType 2 =*/10).bytes(message.nonce);
         if (message.encryptedContent != null && message.hasOwnProperty("encryptedContent"))
-            writer.uint32(/* id 5, wireType 2 =*/42).bytes(message.encryptedContent);
+            writer.uint32(/* id 2, wireType 2 =*/18).bytes(message.encryptedContent);
         return writer;
     };
 
@@ -1789,20 +1754,9 @@ export const ChannelMessage = $root.ChannelMessage = (() => {
             let tag = reader.uint32();
             switch (tag >>> 3) {
             case 1:
-                message.channelId = reader.bytes();
-                break;
-            case 2:
-                if (!(message.parents && message.parents.length))
-                    message.parents = [];
-                message.parents.push(reader.bytes());
-                break;
-            case 3:
-                message.height = reader.int64();
-                break;
-            case 4:
                 message.nonce = reader.bytes();
                 break;
-            case 5:
+            case 2:
                 message.encryptedContent = reader.bytes();
                 break;
             default:
@@ -1840,19 +1794,6 @@ export const ChannelMessage = $root.ChannelMessage = (() => {
     ChannelMessage.verify = function verify(message) {
         if (typeof message !== "object" || message === null)
             return "object expected";
-        if (message.channelId != null && message.hasOwnProperty("channelId"))
-            if (!(message.channelId && typeof message.channelId.length === "number" || $util.isString(message.channelId)))
-                return "channelId: buffer expected";
-        if (message.parents != null && message.hasOwnProperty("parents")) {
-            if (!Array.isArray(message.parents))
-                return "parents: array expected";
-            for (let i = 0; i < message.parents.length; ++i)
-                if (!(message.parents[i] && typeof message.parents[i].length === "number" || $util.isString(message.parents[i])))
-                    return "parents: buffer[] expected";
-        }
-        if (message.height != null && message.hasOwnProperty("height"))
-            if (!$util.isInteger(message.height) && !(message.height && $util.isInteger(message.height.low) && $util.isInteger(message.height.high)))
-                return "height: integer|Long expected";
         if (message.nonce != null && message.hasOwnProperty("nonce"))
             if (!(message.nonce && typeof message.nonce.length === "number" || $util.isString(message.nonce)))
                 return "nonce: buffer expected";
@@ -1874,30 +1815,6 @@ export const ChannelMessage = $root.ChannelMessage = (() => {
         if (object instanceof $root.ChannelMessage)
             return object;
         let message = new $root.ChannelMessage();
-        if (object.channelId != null)
-            if (typeof object.channelId === "string")
-                $util.base64.decode(object.channelId, message.channelId = $util.newBuffer($util.base64.length(object.channelId)), 0);
-            else if (object.channelId.length)
-                message.channelId = object.channelId;
-        if (object.parents) {
-            if (!Array.isArray(object.parents))
-                throw TypeError(".ChannelMessage.parents: array expected");
-            message.parents = [];
-            for (let i = 0; i < object.parents.length; ++i)
-                if (typeof object.parents[i] === "string")
-                    $util.base64.decode(object.parents[i], message.parents[i] = $util.newBuffer($util.base64.length(object.parents[i])), 0);
-                else if (object.parents[i].length)
-                    message.parents[i] = object.parents[i];
-        }
-        if (object.height != null)
-            if ($util.Long)
-                (message.height = $util.Long.fromValue(object.height)).unsigned = false;
-            else if (typeof object.height === "string")
-                message.height = parseInt(object.height, 10);
-            else if (typeof object.height === "number")
-                message.height = object.height;
-            else if (typeof object.height === "object")
-                message.height = new $util.LongBits(object.height.low >>> 0, object.height.high >>> 0).toNumber();
         if (object.nonce != null)
             if (typeof object.nonce === "string")
                 $util.base64.decode(object.nonce, message.nonce = $util.newBuffer($util.base64.length(object.nonce)), 0);
@@ -1924,21 +1841,7 @@ export const ChannelMessage = $root.ChannelMessage = (() => {
         if (!options)
             options = {};
         let object = {};
-        if (options.arrays || options.defaults)
-            object.parents = [];
         if (options.defaults) {
-            if (options.bytes === String)
-                object.channelId = "";
-            else {
-                object.channelId = [];
-                if (options.bytes !== Array)
-                    object.channelId = $util.newBuffer(object.channelId);
-            }
-            if ($util.Long) {
-                let long = new $util.Long(0, 0, false);
-                object.height = options.longs === String ? long.toString() : options.longs === Number ? long.toNumber() : long;
-            } else
-                object.height = options.longs === String ? "0" : 0;
             if (options.bytes === String)
                 object.nonce = "";
             else {
@@ -1954,18 +1857,6 @@ export const ChannelMessage = $root.ChannelMessage = (() => {
                     object.encryptedContent = $util.newBuffer(object.encryptedContent);
             }
         }
-        if (message.channelId != null && message.hasOwnProperty("channelId"))
-            object.channelId = options.bytes === String ? $util.base64.encode(message.channelId, 0, message.channelId.length) : options.bytes === Array ? Array.prototype.slice.call(message.channelId) : message.channelId;
-        if (message.parents && message.parents.length) {
-            object.parents = [];
-            for (let j = 0; j < message.parents.length; ++j)
-                object.parents[j] = options.bytes === String ? $util.base64.encode(message.parents[j], 0, message.parents[j].length) : options.bytes === Array ? Array.prototype.slice.call(message.parents[j]) : message.parents[j];
-        }
-        if (message.height != null && message.hasOwnProperty("height"))
-            if (typeof message.height === "number")
-                object.height = options.longs === String ? String(message.height) : message.height;
-            else
-                object.height = options.longs === String ? $util.Long.prototype.toString.call(message.height) : options.longs === Number ? new $util.LongBits(message.height.low >>> 0, message.height.high >>> 0).toNumber() : message.height;
         if (message.nonce != null && message.hasOwnProperty("nonce"))
             object.nonce = options.bytes === String ? $util.base64.encode(message.nonce, 0, message.nonce.length) : options.bytes === Array ? Array.prototype.slice.call(message.nonce) : message.nonce;
         if (message.encryptedContent != null && message.hasOwnProperty("encryptedContent"))
@@ -2389,6 +2280,8 @@ export const ChannelMessage = $root.ChannelMessage = (() => {
          * Properties of a Content.
          * @memberof ChannelMessage
          * @interface IContent
+         * @property {Array.<Uint8Array>|null} [parents] Content parents
+         * @property {number|Long|null} [height] Content height
          * @property {Array.<ILink>|null} [chain] Content chain
          * @property {number|null} [timestamp] Content timestamp
          * @property {ChannelMessage.IBody|null} [body] Content body
@@ -2404,12 +2297,29 @@ export const ChannelMessage = $root.ChannelMessage = (() => {
          * @param {ChannelMessage.IContent=} [properties] Properties to set
          */
         function Content(properties) {
+            this.parents = [];
             this.chain = [];
             if (properties)
                 for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
                     if (properties[keys[i]] != null)
                         this[keys[i]] = properties[keys[i]];
         }
+
+        /**
+         * Content parents.
+         * @member {Array.<Uint8Array>} parents
+         * @memberof ChannelMessage.Content
+         * @instance
+         */
+        Content.prototype.parents = $util.emptyArray;
+
+        /**
+         * Content height.
+         * @member {number|Long} height
+         * @memberof ChannelMessage.Content
+         * @instance
+         */
+        Content.prototype.height = $util.Long ? $util.Long.fromBits(0,0,false) : 0;
 
         /**
          * Content chain.
@@ -2467,15 +2377,20 @@ export const ChannelMessage = $root.ChannelMessage = (() => {
         Content.encode = function encode(message, writer) {
             if (!writer)
                 writer = $Writer.create();
+            if (message.parents != null && message.parents.length)
+                for (let i = 0; i < message.parents.length; ++i)
+                    writer.uint32(/* id 1, wireType 2 =*/10).bytes(message.parents[i]);
+            if (message.height != null && message.hasOwnProperty("height"))
+                writer.uint32(/* id 2, wireType 0 =*/16).int64(message.height);
             if (message.chain != null && message.chain.length)
                 for (let i = 0; i < message.chain.length; ++i)
-                    $root.Link.encode(message.chain[i], writer.uint32(/* id 1, wireType 2 =*/10).fork()).ldelim();
+                    $root.Link.encode(message.chain[i], writer.uint32(/* id 3, wireType 2 =*/26).fork()).ldelim();
             if (message.timestamp != null && message.hasOwnProperty("timestamp"))
-                writer.uint32(/* id 2, wireType 1 =*/17).double(message.timestamp);
+                writer.uint32(/* id 4, wireType 1 =*/33).double(message.timestamp);
             if (message.body != null && message.hasOwnProperty("body"))
-                $root.ChannelMessage.Body.encode(message.body, writer.uint32(/* id 3, wireType 2 =*/26).fork()).ldelim();
+                $root.ChannelMessage.Body.encode(message.body, writer.uint32(/* id 5, wireType 2 =*/42).fork()).ldelim();
             if (message.signature != null && message.hasOwnProperty("signature"))
-                writer.uint32(/* id 4, wireType 2 =*/34).bytes(message.signature);
+                writer.uint32(/* id 6, wireType 2 =*/50).bytes(message.signature);
             return writer;
         };
 
@@ -2511,17 +2426,25 @@ export const ChannelMessage = $root.ChannelMessage = (() => {
                 let tag = reader.uint32();
                 switch (tag >>> 3) {
                 case 1:
+                    if (!(message.parents && message.parents.length))
+                        message.parents = [];
+                    message.parents.push(reader.bytes());
+                    break;
+                case 2:
+                    message.height = reader.int64();
+                    break;
+                case 3:
                     if (!(message.chain && message.chain.length))
                         message.chain = [];
                     message.chain.push($root.Link.decode(reader, reader.uint32()));
                     break;
-                case 2:
+                case 4:
                     message.timestamp = reader.double();
                     break;
-                case 3:
+                case 5:
                     message.body = $root.ChannelMessage.Body.decode(reader, reader.uint32());
                     break;
-                case 4:
+                case 6:
                     message.signature = reader.bytes();
                     break;
                 default:
@@ -2559,6 +2482,16 @@ export const ChannelMessage = $root.ChannelMessage = (() => {
         Content.verify = function verify(message) {
             if (typeof message !== "object" || message === null)
                 return "object expected";
+            if (message.parents != null && message.hasOwnProperty("parents")) {
+                if (!Array.isArray(message.parents))
+                    return "parents: array expected";
+                for (let i = 0; i < message.parents.length; ++i)
+                    if (!(message.parents[i] && typeof message.parents[i].length === "number" || $util.isString(message.parents[i])))
+                        return "parents: buffer[] expected";
+            }
+            if (message.height != null && message.hasOwnProperty("height"))
+                if (!$util.isInteger(message.height) && !(message.height && $util.isInteger(message.height.low) && $util.isInteger(message.height.high)))
+                    return "height: integer|Long expected";
             if (message.chain != null && message.hasOwnProperty("chain")) {
                 if (!Array.isArray(message.chain))
                     return "chain: array expected";
@@ -2594,6 +2527,25 @@ export const ChannelMessage = $root.ChannelMessage = (() => {
             if (object instanceof $root.ChannelMessage.Content)
                 return object;
             let message = new $root.ChannelMessage.Content();
+            if (object.parents) {
+                if (!Array.isArray(object.parents))
+                    throw TypeError(".ChannelMessage.Content.parents: array expected");
+                message.parents = [];
+                for (let i = 0; i < object.parents.length; ++i)
+                    if (typeof object.parents[i] === "string")
+                        $util.base64.decode(object.parents[i], message.parents[i] = $util.newBuffer($util.base64.length(object.parents[i])), 0);
+                    else if (object.parents[i].length)
+                        message.parents[i] = object.parents[i];
+            }
+            if (object.height != null)
+                if ($util.Long)
+                    (message.height = $util.Long.fromValue(object.height)).unsigned = false;
+                else if (typeof object.height === "string")
+                    message.height = parseInt(object.height, 10);
+                else if (typeof object.height === "number")
+                    message.height = object.height;
+                else if (typeof object.height === "object")
+                    message.height = new $util.LongBits(object.height.low >>> 0, object.height.high >>> 0).toNumber();
             if (object.chain) {
                 if (!Array.isArray(object.chain))
                     throw TypeError(".ChannelMessage.Content.chain: array expected");
@@ -2632,9 +2584,16 @@ export const ChannelMessage = $root.ChannelMessage = (() => {
             if (!options)
                 options = {};
             let object = {};
-            if (options.arrays || options.defaults)
+            if (options.arrays || options.defaults) {
+                object.parents = [];
                 object.chain = [];
+            }
             if (options.defaults) {
+                if ($util.Long) {
+                    let long = new $util.Long(0, 0, false);
+                    object.height = options.longs === String ? long.toString() : options.longs === Number ? long.toNumber() : long;
+                } else
+                    object.height = options.longs === String ? "0" : 0;
                 object.timestamp = 0;
                 object.body = null;
                 if (options.bytes === String)
@@ -2645,6 +2604,16 @@ export const ChannelMessage = $root.ChannelMessage = (() => {
                         object.signature = $util.newBuffer(object.signature);
                 }
             }
+            if (message.parents && message.parents.length) {
+                object.parents = [];
+                for (let j = 0; j < message.parents.length; ++j)
+                    object.parents[j] = options.bytes === String ? $util.base64.encode(message.parents[j], 0, message.parents[j].length) : options.bytes === Array ? Array.prototype.slice.call(message.parents[j]) : message.parents[j];
+            }
+            if (message.height != null && message.hasOwnProperty("height"))
+                if (typeof message.height === "number")
+                    object.height = options.longs === String ? String(message.height) : message.height;
+                else
+                    object.height = options.longs === String ? $util.Long.prototype.toString.call(message.height) : options.longs === Number ? new $util.LongBits(message.height.low >>> 0, message.height.high >>> 0).toNumber() : message.height;
             if (message.chain && message.chain.length) {
                 object.chain = [];
                 for (let j = 0; j < message.chain.length; ++j)

--- a/lib/messages.js
+++ b/lib/messages.js
@@ -3857,7 +3857,8 @@ export const SyncRequest = $root.SyncRequest = (() => {
      * @interface ISyncRequest
      * @property {Uint8Array|null} [channelId] SyncRequest channelId
      * @property {number|null} [seq] SyncRequest seq
-     * @property {Array.<ILink>|null} [chain] SyncRequest chain
+     * @property {SyncRequest.IChain|null} [chain] SyncRequest chain
+     * @property {Uint8Array|null} [publicKey] SyncRequest publicKey
      * @property {Uint8Array|null} [nonce] SyncRequest nonce
      * @property {Uint8Array|null} [box] SyncRequest box
      */
@@ -3871,7 +3872,6 @@ export const SyncRequest = $root.SyncRequest = (() => {
      * @param {ISyncRequest=} [properties] Properties to set
      */
     function SyncRequest(properties) {
-        this.chain = [];
         if (properties)
             for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
                 if (properties[keys[i]] != null)
@@ -3896,11 +3896,19 @@ export const SyncRequest = $root.SyncRequest = (() => {
 
     /**
      * SyncRequest chain.
-     * @member {Array.<ILink>} chain
+     * @member {SyncRequest.IChain|null|undefined} chain
      * @memberof SyncRequest
      * @instance
      */
-    SyncRequest.prototype.chain = $util.emptyArray;
+    SyncRequest.prototype.chain = null;
+
+    /**
+     * SyncRequest publicKey.
+     * @member {Uint8Array} publicKey
+     * @memberof SyncRequest
+     * @instance
+     */
+    SyncRequest.prototype.publicKey = $util.newBuffer([]);
 
     /**
      * SyncRequest nonce.
@@ -3917,6 +3925,20 @@ export const SyncRequest = $root.SyncRequest = (() => {
      * @instance
      */
     SyncRequest.prototype.box = $util.newBuffer([]);
+
+    // OneOf field names bound to virtual getters and setters
+    let $oneOfFields;
+
+    /**
+     * SyncRequest identity.
+     * @member {"chain"|"publicKey"|undefined} identity
+     * @memberof SyncRequest
+     * @instance
+     */
+    Object.defineProperty(SyncRequest.prototype, "identity", {
+        get: $util.oneOfGetter($oneOfFields = ["chain", "publicKey"]),
+        set: $util.oneOfSetter($oneOfFields)
+    });
 
     /**
      * Creates a new SyncRequest instance using the specified properties.
@@ -3946,13 +3968,14 @@ export const SyncRequest = $root.SyncRequest = (() => {
             writer.uint32(/* id 1, wireType 2 =*/10).bytes(message.channelId);
         if (message.seq != null && message.hasOwnProperty("seq"))
             writer.uint32(/* id 2, wireType 0 =*/16).uint32(message.seq);
-        if (message.chain != null && message.chain.length)
-            for (let i = 0; i < message.chain.length; ++i)
-                $root.Link.encode(message.chain[i], writer.uint32(/* id 3, wireType 2 =*/26).fork()).ldelim();
+        if (message.chain != null && message.hasOwnProperty("chain"))
+            $root.SyncRequest.Chain.encode(message.chain, writer.uint32(/* id 3, wireType 2 =*/26).fork()).ldelim();
+        if (message.publicKey != null && message.hasOwnProperty("publicKey"))
+            writer.uint32(/* id 4, wireType 2 =*/34).bytes(message.publicKey);
         if (message.nonce != null && message.hasOwnProperty("nonce"))
-            writer.uint32(/* id 4, wireType 2 =*/34).bytes(message.nonce);
+            writer.uint32(/* id 5, wireType 2 =*/42).bytes(message.nonce);
         if (message.box != null && message.hasOwnProperty("box"))
-            writer.uint32(/* id 5, wireType 2 =*/42).bytes(message.box);
+            writer.uint32(/* id 6, wireType 2 =*/50).bytes(message.box);
         return writer;
     };
 
@@ -3994,14 +4017,15 @@ export const SyncRequest = $root.SyncRequest = (() => {
                 message.seq = reader.uint32();
                 break;
             case 3:
-                if (!(message.chain && message.chain.length))
-                    message.chain = [];
-                message.chain.push($root.Link.decode(reader, reader.uint32()));
+                message.chain = $root.SyncRequest.Chain.decode(reader, reader.uint32());
                 break;
             case 4:
-                message.nonce = reader.bytes();
+                message.publicKey = reader.bytes();
                 break;
             case 5:
+                message.nonce = reader.bytes();
+                break;
+            case 6:
                 message.box = reader.bytes();
                 break;
             default:
@@ -4039,6 +4063,7 @@ export const SyncRequest = $root.SyncRequest = (() => {
     SyncRequest.verify = function verify(message) {
         if (typeof message !== "object" || message === null)
             return "object expected";
+        let properties = {};
         if (message.channelId != null && message.hasOwnProperty("channelId"))
             if (!(message.channelId && typeof message.channelId.length === "number" || $util.isString(message.channelId)))
                 return "channelId: buffer expected";
@@ -4046,13 +4071,19 @@ export const SyncRequest = $root.SyncRequest = (() => {
             if (!$util.isInteger(message.seq))
                 return "seq: integer expected";
         if (message.chain != null && message.hasOwnProperty("chain")) {
-            if (!Array.isArray(message.chain))
-                return "chain: array expected";
-            for (let i = 0; i < message.chain.length; ++i) {
-                let error = $root.Link.verify(message.chain[i]);
+            properties.identity = 1;
+            {
+                let error = $root.SyncRequest.Chain.verify(message.chain);
                 if (error)
                     return "chain." + error;
             }
+        }
+        if (message.publicKey != null && message.hasOwnProperty("publicKey")) {
+            if (properties.identity === 1)
+                return "identity: multiple values";
+            properties.identity = 1;
+            if (!(message.publicKey && typeof message.publicKey.length === "number" || $util.isString(message.publicKey)))
+                return "publicKey: buffer expected";
         }
         if (message.nonce != null && message.hasOwnProperty("nonce"))
             if (!(message.nonce && typeof message.nonce.length === "number" || $util.isString(message.nonce)))
@@ -4082,16 +4113,16 @@ export const SyncRequest = $root.SyncRequest = (() => {
                 message.channelId = object.channelId;
         if (object.seq != null)
             message.seq = object.seq >>> 0;
-        if (object.chain) {
-            if (!Array.isArray(object.chain))
-                throw TypeError(".SyncRequest.chain: array expected");
-            message.chain = [];
-            for (let i = 0; i < object.chain.length; ++i) {
-                if (typeof object.chain[i] !== "object")
-                    throw TypeError(".SyncRequest.chain: object expected");
-                message.chain[i] = $root.Link.fromObject(object.chain[i]);
-            }
+        if (object.chain != null) {
+            if (typeof object.chain !== "object")
+                throw TypeError(".SyncRequest.chain: object expected");
+            message.chain = $root.SyncRequest.Chain.fromObject(object.chain);
         }
+        if (object.publicKey != null)
+            if (typeof object.publicKey === "string")
+                $util.base64.decode(object.publicKey, message.publicKey = $util.newBuffer($util.base64.length(object.publicKey)), 0);
+            else if (object.publicKey.length)
+                message.publicKey = object.publicKey;
         if (object.nonce != null)
             if (typeof object.nonce === "string")
                 $util.base64.decode(object.nonce, message.nonce = $util.newBuffer($util.base64.length(object.nonce)), 0);
@@ -4118,8 +4149,6 @@ export const SyncRequest = $root.SyncRequest = (() => {
         if (!options)
             options = {};
         let object = {};
-        if (options.arrays || options.defaults)
-            object.chain = [];
         if (options.defaults) {
             if (options.bytes === String)
                 object.channelId = "";
@@ -4148,10 +4177,15 @@ export const SyncRequest = $root.SyncRequest = (() => {
             object.channelId = options.bytes === String ? $util.base64.encode(message.channelId, 0, message.channelId.length) : options.bytes === Array ? Array.prototype.slice.call(message.channelId) : message.channelId;
         if (message.seq != null && message.hasOwnProperty("seq"))
             object.seq = message.seq;
-        if (message.chain && message.chain.length) {
-            object.chain = [];
-            for (let j = 0; j < message.chain.length; ++j)
-                object.chain[j] = $root.Link.toObject(message.chain[j], options);
+        if (message.chain != null && message.hasOwnProperty("chain")) {
+            object.chain = $root.SyncRequest.Chain.toObject(message.chain, options);
+            if (options.oneofs)
+                object.identity = "chain";
+        }
+        if (message.publicKey != null && message.hasOwnProperty("publicKey")) {
+            object.publicKey = options.bytes === String ? $util.base64.encode(message.publicKey, 0, message.publicKey.length) : options.bytes === Array ? Array.prototype.slice.call(message.publicKey) : message.publicKey;
+            if (options.oneofs)
+                object.identity = "publicKey";
         }
         if (message.nonce != null && message.hasOwnProperty("nonce"))
             object.nonce = options.bytes === String ? $util.base64.encode(message.nonce, 0, message.nonce.length) : options.bytes === Array ? Array.prototype.slice.call(message.nonce) : message.nonce;
@@ -4414,6 +4448,214 @@ export const SyncRequest = $root.SyncRequest = (() => {
         };
 
         return Content;
+    })();
+
+    SyncRequest.Chain = (function() {
+
+        /**
+         * Properties of a Chain.
+         * @memberof SyncRequest
+         * @interface IChain
+         * @property {Array.<ILink>|null} [links] Chain links
+         */
+
+        /**
+         * Constructs a new Chain.
+         * @memberof SyncRequest
+         * @classdesc Represents a Chain.
+         * @implements IChain
+         * @constructor
+         * @param {SyncRequest.IChain=} [properties] Properties to set
+         */
+        function Chain(properties) {
+            this.links = [];
+            if (properties)
+                for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                    if (properties[keys[i]] != null)
+                        this[keys[i]] = properties[keys[i]];
+        }
+
+        /**
+         * Chain links.
+         * @member {Array.<ILink>} links
+         * @memberof SyncRequest.Chain
+         * @instance
+         */
+        Chain.prototype.links = $util.emptyArray;
+
+        /**
+         * Creates a new Chain instance using the specified properties.
+         * @function create
+         * @memberof SyncRequest.Chain
+         * @static
+         * @param {SyncRequest.IChain=} [properties] Properties to set
+         * @returns {SyncRequest.Chain} Chain instance
+         */
+        Chain.create = function create(properties) {
+            return new Chain(properties);
+        };
+
+        /**
+         * Encodes the specified Chain message. Does not implicitly {@link SyncRequest.Chain.verify|verify} messages.
+         * @function encode
+         * @memberof SyncRequest.Chain
+         * @static
+         * @param {SyncRequest.IChain} message Chain message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        Chain.encode = function encode(message, writer) {
+            if (!writer)
+                writer = $Writer.create();
+            if (message.links != null && message.links.length)
+                for (let i = 0; i < message.links.length; ++i)
+                    $root.Link.encode(message.links[i], writer.uint32(/* id 1, wireType 2 =*/10).fork()).ldelim();
+            return writer;
+        };
+
+        /**
+         * Encodes the specified Chain message, length delimited. Does not implicitly {@link SyncRequest.Chain.verify|verify} messages.
+         * @function encodeDelimited
+         * @memberof SyncRequest.Chain
+         * @static
+         * @param {SyncRequest.IChain} message Chain message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        Chain.encodeDelimited = function encodeDelimited(message, writer) {
+            return this.encode(message, writer).ldelim();
+        };
+
+        /**
+         * Decodes a Chain message from the specified reader or buffer.
+         * @function decode
+         * @memberof SyncRequest.Chain
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @param {number} [length] Message length if known beforehand
+         * @returns {SyncRequest.Chain} Chain
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        Chain.decode = function decode(reader, length) {
+            if (!(reader instanceof $Reader))
+                reader = $Reader.create(reader);
+            let end = length === undefined ? reader.len : reader.pos + length, message = new $root.SyncRequest.Chain();
+            while (reader.pos < end) {
+                let tag = reader.uint32();
+                switch (tag >>> 3) {
+                case 1:
+                    if (!(message.links && message.links.length))
+                        message.links = [];
+                    message.links.push($root.Link.decode(reader, reader.uint32()));
+                    break;
+                default:
+                    reader.skipType(tag & 7);
+                    break;
+                }
+            }
+            return message;
+        };
+
+        /**
+         * Decodes a Chain message from the specified reader or buffer, length delimited.
+         * @function decodeDelimited
+         * @memberof SyncRequest.Chain
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @returns {SyncRequest.Chain} Chain
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        Chain.decodeDelimited = function decodeDelimited(reader) {
+            if (!(reader instanceof $Reader))
+                reader = new $Reader(reader);
+            return this.decode(reader, reader.uint32());
+        };
+
+        /**
+         * Verifies a Chain message.
+         * @function verify
+         * @memberof SyncRequest.Chain
+         * @static
+         * @param {Object.<string,*>} message Plain object to verify
+         * @returns {string|null} `null` if valid, otherwise the reason why it is not
+         */
+        Chain.verify = function verify(message) {
+            if (typeof message !== "object" || message === null)
+                return "object expected";
+            if (message.links != null && message.hasOwnProperty("links")) {
+                if (!Array.isArray(message.links))
+                    return "links: array expected";
+                for (let i = 0; i < message.links.length; ++i) {
+                    let error = $root.Link.verify(message.links[i]);
+                    if (error)
+                        return "links." + error;
+                }
+            }
+            return null;
+        };
+
+        /**
+         * Creates a Chain message from a plain object. Also converts values to their respective internal types.
+         * @function fromObject
+         * @memberof SyncRequest.Chain
+         * @static
+         * @param {Object.<string,*>} object Plain object
+         * @returns {SyncRequest.Chain} Chain
+         */
+        Chain.fromObject = function fromObject(object) {
+            if (object instanceof $root.SyncRequest.Chain)
+                return object;
+            let message = new $root.SyncRequest.Chain();
+            if (object.links) {
+                if (!Array.isArray(object.links))
+                    throw TypeError(".SyncRequest.Chain.links: array expected");
+                message.links = [];
+                for (let i = 0; i < object.links.length; ++i) {
+                    if (typeof object.links[i] !== "object")
+                        throw TypeError(".SyncRequest.Chain.links: object expected");
+                    message.links[i] = $root.Link.fromObject(object.links[i]);
+                }
+            }
+            return message;
+        };
+
+        /**
+         * Creates a plain object from a Chain message. Also converts values to other types if specified.
+         * @function toObject
+         * @memberof SyncRequest.Chain
+         * @static
+         * @param {SyncRequest.Chain} message Chain
+         * @param {$protobuf.IConversionOptions} [options] Conversion options
+         * @returns {Object.<string,*>} Plain object
+         */
+        Chain.toObject = function toObject(message, options) {
+            if (!options)
+                options = {};
+            let object = {};
+            if (options.arrays || options.defaults)
+                object.links = [];
+            if (message.links && message.links.length) {
+                object.links = [];
+                for (let j = 0; j < message.links.length; ++j)
+                    object.links[j] = $root.Link.toObject(message.links[j], options);
+            }
+            return object;
+        };
+
+        /**
+         * Converts this Chain to JSON.
+         * @function toJSON
+         * @memberof SyncRequest.Chain
+         * @instance
+         * @returns {Object.<string,*>} JSON object
+         */
+        Chain.prototype.toJSON = function toJSON() {
+            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+        };
+
+        return Chain;
     })();
 
     return SyncRequest;
@@ -6208,6 +6450,7 @@ export const Channel = $root.Channel = (() => {
      * @interface IChannel
      * @property {Uint8Array|null} [publicKey] Channel publicKey
      * @property {string|null} [name] Channel name
+     * @property {boolean|null} [isFeed] Channel isFeed
      * @property {string|null} [metadata] Channel metadata
      */
 
@@ -6241,6 +6484,14 @@ export const Channel = $root.Channel = (() => {
      * @instance
      */
     Channel.prototype.name = "";
+
+    /**
+     * Channel isFeed.
+     * @member {boolean} isFeed
+     * @memberof Channel
+     * @instance
+     */
+    Channel.prototype.isFeed = false;
 
     /**
      * Channel metadata.
@@ -6278,6 +6529,8 @@ export const Channel = $root.Channel = (() => {
             writer.uint32(/* id 1, wireType 2 =*/10).bytes(message.publicKey);
         if (message.name != null && message.hasOwnProperty("name"))
             writer.uint32(/* id 2, wireType 2 =*/18).string(message.name);
+        if (message.isFeed != null && message.hasOwnProperty("isFeed"))
+            writer.uint32(/* id 3, wireType 0 =*/24).bool(message.isFeed);
         if (message.metadata != null && message.hasOwnProperty("metadata"))
             writer.uint32(/* id 4, wireType 2 =*/34).string(message.metadata);
         return writer;
@@ -6319,6 +6572,9 @@ export const Channel = $root.Channel = (() => {
                 break;
             case 2:
                 message.name = reader.string();
+                break;
+            case 3:
+                message.isFeed = reader.bool();
                 break;
             case 4:
                 message.metadata = reader.string();
@@ -6364,6 +6620,9 @@ export const Channel = $root.Channel = (() => {
         if (message.name != null && message.hasOwnProperty("name"))
             if (!$util.isString(message.name))
                 return "name: string expected";
+        if (message.isFeed != null && message.hasOwnProperty("isFeed"))
+            if (typeof message.isFeed !== "boolean")
+                return "isFeed: boolean expected";
         if (message.metadata != null && message.hasOwnProperty("metadata"))
             if (!$util.isString(message.metadata))
                 return "metadata: string expected";
@@ -6389,6 +6648,8 @@ export const Channel = $root.Channel = (() => {
                 message.publicKey = object.publicKey;
         if (object.name != null)
             message.name = String(object.name);
+        if (object.isFeed != null)
+            message.isFeed = Boolean(object.isFeed);
         if (object.metadata != null)
             message.metadata = String(object.metadata);
         return message;
@@ -6416,12 +6677,15 @@ export const Channel = $root.Channel = (() => {
                     object.publicKey = $util.newBuffer(object.publicKey);
             }
             object.name = "";
+            object.isFeed = false;
             object.metadata = "";
         }
         if (message.publicKey != null && message.hasOwnProperty("publicKey"))
             object.publicKey = options.bytes === String ? $util.base64.encode(message.publicKey, 0, message.publicKey.length) : options.bytes === Array ? Array.prototype.slice.call(message.publicKey) : message.publicKey;
         if (message.name != null && message.hasOwnProperty("name"))
             object.name = message.name;
+        if (message.isFeed != null && message.hasOwnProperty("isFeed"))
+            object.isFeed = message.isFeed;
         if (message.metadata != null && message.hasOwnProperty("metadata"))
             object.metadata = message.metadata;
         return object;

--- a/lib/messages.proto
+++ b/lib/messages.proto
@@ -86,14 +86,12 @@ message ChannelMessage {
 }
 
 message Query {
-  bytes channel_id = 1;
-  uint32 seq = 2;
   oneof cursor {
-    int64 height = 3;
-    bytes hash = 4;
+    int64 height = 1;
+    bytes hash = 2;
   }
-  bool is_backward = 5;
-  uint32 limit = 6;
+  bool is_backward = 3;
+  uint32 limit = 4;
 }
 
 message QueryResponse {
@@ -102,28 +100,40 @@ message QueryResponse {
     bytes hash = 2;
   }
 
-  bytes channel_id = 1;
-  uint32 seq = 2;
-  repeated Abbreviated abbreviated_messages = 3;
-  bytes forward_hash = 4;
-  bytes backward_hash = 5;
+  repeated Abbreviated abbreviated_messages = 1;
+  bytes forward_hash = 2;
+  bytes backward_hash = 3;
 }
 
 message Bulk {
-  bytes channel_id = 1;
-  uint32 seq = 2;
-  repeated bytes hashes = 3;
+  repeated bytes hashes = 1;
 }
 
 message BulkResponse {
-  bytes channel_id = 1;
-  uint32 seq = 2;
-  repeated ChannelMessage messages = 3;
-  uint32 forward_index = 4;
+  repeated ChannelMessage messages = 1;
+  uint32 forward_index = 2;
 }
 
 message Error {
   string reason = 1;
+}
+
+message ChannelPacket {
+  message Content {
+    oneof content {
+      Query query = 1;
+      QueryResponse query_response = 2;
+      Bulk bulk = 3;
+      BulkResponse bulk_response = 4;
+    }
+  }
+
+  bytes channel_id = 1;
+  uint32 seq = 2;
+
+  // `crypto_secretbox_easy`
+  bytes nonce = 3;
+  bytes box = 4;
 }
 
 message Notification {
@@ -136,13 +146,10 @@ message Packet {
     EncryptedInvite invite = 2;
 
     // Synchronization
-    Query query = 3;
-    QueryResponse query_response = 4;
-    Bulk bulk = 5;
-    BulkResponse bulk_response = 6;
+    ChannelPacket channel_packet = 3;
 
     // Request synchronization on new messages
-    Notification notification = 7;
+    Notification notification = 4;
   }
 }
 

--- a/lib/messages.proto
+++ b/lib/messages.proto
@@ -43,7 +43,7 @@ message EncryptedInvite {
   bytes box = 2;
 }
 
-// QR Code
+// Could be a QR Code, or a text message
 message InviteRequest {
   bytes peer_id = 1;
   bytes trustee_pub_key = 2;

--- a/lib/messages.proto
+++ b/lib/messages.proto
@@ -135,8 +135,8 @@ message SyncRequest {
 message SyncResponse {
   message Content {
     oneof content {
-      QueryResponse query = 1;
-      BulkResponse bulk = 2;
+      QueryResponse queryResponse = 1;
+      BulkResponse bulkResponse = 2;
     }
   }
 

--- a/lib/messages.proto
+++ b/lib/messages.proto
@@ -63,14 +63,11 @@ message ChannelMessage {
 
   message Content {
     message TBS {
-      repeated Link chain = 1;
-      double timestamp = 2;
-      Body body = 3;
-
-      // NOTE: Despite these fields being outside of content they have to be
-      // included here to prevent replay attacks
-      repeated bytes parents = 4;
-      int64 height = 5;
+      repeated bytes parents = 1;
+      int64 height = 2;
+      repeated Link chain = 3;
+      double timestamp = 4;
+      Body body = 5;
     }
 
     // NOTE: can be empty only in the root message

--- a/lib/messages.proto
+++ b/lib/messages.proto
@@ -61,15 +61,7 @@ message ChannelMessage {
     }
   }
 
-  message Content {
-    message TBS {
-      repeated bytes parents = 1;
-      int64 height = 2;
-      repeated Link chain = 3;
-      double timestamp = 4;
-      Body body = 5;
-    }
-
+  message TBS {
     // NOTE: can be empty only in the root message
     repeated bytes parents = 1;
 
@@ -85,19 +77,12 @@ message ChannelMessage {
 
     // body of the message
     Body body = 5;
-
-    bytes signature = 6;
   }
 
-  message EncryptionKeyInput {
-    bytes channel_pub_key = 1;
-  }
+  TBS tbs = 1;
 
-  // Encryption nonce for Sodium
-  bytes nonce = 1;
-
-  // NOTE: encryption key = HASH(EncryptionKeyInput, 'vowlink-symmetric')
-  bytes encrypted_content = 2;
+  // NOTE: `signature` has to be made by the leaf key in the `tbs.chain`
+  bytes signature = 2;
 }
 
 message Query {

--- a/lib/messages.proto
+++ b/lib/messages.proto
@@ -86,12 +86,14 @@ message ChannelMessage {
 }
 
 message Query {
+  repeated Link chain = 1;
+
   oneof cursor {
-    int64 height = 1;
-    bytes hash = 2;
+    int64 height = 2;
+    bytes hash = 3;
   }
-  bool is_backward = 3;
-  uint32 limit = 4;
+  bool is_backward = 4;
+  uint32 limit = 5;
 }
 
 message QueryResponse {
@@ -106,7 +108,9 @@ message QueryResponse {
 }
 
 message Bulk {
-  repeated bytes hashes = 1;
+  repeated Link chain = 1;
+
+  repeated bytes hashes = 2;
 }
 
 message BulkResponse {

--- a/lib/messages.proto
+++ b/lib/messages.proto
@@ -122,13 +122,23 @@ message SyncRequest {
     }
   }
 
+  message Chain {
+    repeated Link links = 1;
+  }
+
   bytes channel_id = 1;
   uint32 seq = 2;
-  repeated Link chain = 3;
+
+  oneof identity {
+    Chain chain = 3;
+
+    // Only for public feeds
+    bytes public_key = 4;
+  }
 
   // `crypto_secretbox_easy`
-  bytes nonce = 4;
-  bytes box = 5;
+  bytes nonce = 5;
+  bytes box = 6;
 }
 
 // TODO(indutny): clarify sync response to unknown channel
@@ -190,6 +200,7 @@ message Identity {
 message Channel {
   bytes public_key = 1;
   string name = 2;
+  bool is_feed = 3;
 
   string metadata = 4;
 }

--- a/lib/messages.proto
+++ b/lib/messages.proto
@@ -17,12 +17,12 @@ message Link {
   message TBS {
     bytes trustee_pub_key = 1;
     string trustee_display_name = 2;
-    double valid_from = 4;
-    double valid_to = 5;
+    double valid_from = 3;
+    double valid_to = 4;
 
     // NOTE: This MUST be filled either by sender/recipient before
     // generating/verifying the signature below.
-    bytes channel_id = 6;
+    bytes channel_id = 5;
   }
 
   TBS tbs = 1;
@@ -33,7 +33,7 @@ message Invite {
   bytes channel_pub_key = 1;
   string channel_name = 2;
 
-  repeated Link chain = 4;
+  repeated Link chain = 3;
 }
 
 message EncryptedInvite {
@@ -73,36 +73,34 @@ message ChannelMessage {
       int64 height = 5;
     }
 
+    // NOTE: can be empty only in the root message
+    repeated bytes parents = 1;
+
+    // height = max(p.height for p in parents)
+    int64 height = 2;
+
     // Link chain that leads from the channel's public key to the signer of
     // this message
-    repeated Link chain = 1;
+    repeated Link chain = 3;
 
     // Floating point unix time
-    double timestamp = 2;
+    double timestamp = 4;
 
     // body of the message
-    Body body = 3;
+    Body body = 5;
 
-    bytes signature = 4;
+    bytes signature = 6;
   }
 
   message EncryptionKeyInput {
     bytes channel_pub_key = 1;
   }
 
-  bytes channel_id = 1;
-
-  // NOTE: can be empty only in the root message
-  repeated bytes parents = 2;
-
-  // height = max(p.height for p in parents)
-  int64 height = 3;
-
   // Encryption nonce for Sodium
-  bytes nonce = 4;
+  bytes nonce = 1;
 
   // NOTE: encryption key = HASH(EncryptionKeyInput, 'vowlink-symmetric')
-  bytes encrypted_content = 5;
+  bytes encrypted_content = 2;
 }
 
 message Query {

--- a/lib/messages.proto
+++ b/lib/messages.proto
@@ -132,7 +132,7 @@ message SyncRequest {
   oneof identity {
     Chain chain = 3;
 
-    // Only for public feeds
+    // Only for read-only feeds
     bytes public_key = 4;
   }
 
@@ -141,7 +141,6 @@ message SyncRequest {
   bytes box = 6;
 }
 
-// TODO(indutny): clarify sync response to unknown channel
 message SyncResponse {
   message Content {
     oneof content {
@@ -153,7 +152,9 @@ message SyncResponse {
   bytes channel_id = 1;
   uint32 seq = 2;
 
-  // Encrypted with `crypto_box_seal` using `chain.leaf_key` from `SyncRequest`
+  // Encrypted with `crypto_box_seal` using `sync_request.chain.leaf_key`
+  // from `SyncRequest` for channels and `sync_request.public_key` for
+  // read-only feeds
   bytes box = 3;
 }
 

--- a/lib/messages.proto
+++ b/lib/messages.proto
@@ -86,14 +86,12 @@ message ChannelMessage {
 }
 
 message Query {
-  repeated Link chain = 1;
-
   oneof cursor {
-    int64 height = 2;
-    bytes hash = 3;
+    int64 height = 1;
+    bytes hash = 2;
   }
-  bool is_backward = 4;
-  uint32 limit = 5;
+  bool is_backward = 3;
+  uint32 limit = 4;
 }
 
 message QueryResponse {
@@ -108,9 +106,7 @@ message QueryResponse {
 }
 
 message Bulk {
-  repeated Link chain = 1;
-
-  repeated bytes hashes = 2;
+  repeated bytes hashes = 1;
 }
 
 message BulkResponse {
@@ -118,26 +114,41 @@ message BulkResponse {
   uint32 forward_index = 2;
 }
 
-message Error {
-  string reason = 1;
-}
-
-message ChannelPacket {
+message SyncRequest {
   message Content {
     oneof content {
       Query query = 1;
-      QueryResponse query_response = 2;
-      Bulk bulk = 3;
-      BulkResponse bulk_response = 4;
+      Bulk bulk = 2;
+    }
+  }
+
+  bytes channel_id = 1;
+  uint32 seq = 2;
+  repeated Link chain = 3;
+
+  // `crypto_secretbox_easy`
+  bytes nonce = 4;
+  bytes box = 5;
+}
+
+// TODO(indutny): clarify sync response to unknown channel
+message SyncResponse {
+  message Content {
+    oneof content {
+      QueryResponse query = 1;
+      BulkResponse bulk = 2;
     }
   }
 
   bytes channel_id = 1;
   uint32 seq = 2;
 
-  // `crypto_secretbox_easy`
-  bytes nonce = 3;
-  bytes box = 4;
+  // Encrypted with `crypto_box_seal` using `chain.leaf_key` from `SyncRequest`
+  bytes box = 3;
+}
+
+message Error {
+  string reason = 1;
 }
 
 message Notification {
@@ -150,10 +161,11 @@ message Packet {
     EncryptedInvite invite = 2;
 
     // Synchronization
-    ChannelPacket channel_packet = 3;
+    SyncRequest sync_request = 3;
+    SyncResponse sync_response = 4;
 
     // Request synchronization on new messages
-    Notification notification = 4;
+    Notification notification = 5;
   }
 }
 

--- a/lib/peer.js
+++ b/lib/peer.js
@@ -262,7 +262,7 @@ export default class Peer {
 
       // Send back empty packet
       await this.socket.send(PPacket.encode({
-        channelPacket: {
+        syncResponse: {
           channelId: packet.channelId,
           seq,
         },
@@ -270,13 +270,8 @@ export default class Peer {
       return;
     }
 
-    if (!packet.box || packet.box.length === 0) {
-      await this.getSyncAgent(channel).receiveEmptyResponse(seq);
-      return;
-    }
-
-    const chain = Chain.deserialize(packet.chain);
-    if (!chain.verify(this.channel)) {
+    const chain = Chain.deserialize(packet.chain, { sodium: this.sodium });
+    if (!chain.verify(channel)) {
       throw new BanError('Invalid SyncRequest chain');
     }
 
@@ -300,7 +295,7 @@ export default class Peer {
       throw Error('Internal error: missing response');
     }
 
-    const leafKey = chain.getLeafKey();
+    const leafKey = chain.getLeafKey(channel);
     const encoded = PSyncResponse.Content.encode(response).finish();
 
     const box = Identity.encryptFor(leafKey, encoded, { sodium: this.sodium });
@@ -321,6 +316,11 @@ export default class Peer {
 
     if (!channel) {
       this.debug('sync response to unknown channel, ignoring');
+      return;
+    }
+
+    if (!packet.box || packet.box.length === 0) {
+      await this.getSyncAgent(channel).receiveEmptyResponse(seq);
       return;
     }
 

--- a/lib/peer.js
+++ b/lib/peer.js
@@ -8,6 +8,7 @@ import {
   Hello as PHello,
   Shake as PShake,
   Packet as PPacket,
+  ChannelPacket as PChannelPacket,
 } from './messages';
 import SyncAgent from './sync-agent';
 import { compareDistance, BanError } from './utils';
@@ -143,17 +144,8 @@ export default class Peer {
         case 'invite':
           await this.onInvite(packet.invite);
           break;
-        case 'query':
-          await this.onQuery(packet.query);
-          break;
-        case 'queryResponse':
-          await this.onQueryResponse(packet.queryResponse);
-          break;
-        case 'bulk':
-          await this.onBulk(packet.bulk);
-          break;
-        case 'bulkResponse':
-          await this.onBulkResponse(packet.bulkResponse);
+        case 'channelPacket':
+          await this.onChannelPacket(packet.channelPacket);
           break;
         case 'notification':
           await this.onNotification(packet.notification);
@@ -253,33 +245,81 @@ export default class Peer {
   }
 
   /** **(Internal)** */
-  async onQuery(packet) {
-    Channel.checkId(packet.channelId, 'Invalid channelId in Query');
-    if (packet.cursor === 'hash') {
-      Message.checkHash(packet.hash, 'Invalid cursor.hash in Query');
-    }
-
+  async onChannelPacket(packet) {
+    Channel.checkId(packet.channelId, 'Invalid channelId in ChannelPacket');
     const channel = this.getChannel(packet.channelId);
+    const seq = packet.seq;
+
     if (!channel) {
-      this.debug('responding to query for unknown channel');
+      this.debug('responding to channel packet for unknown channel');
+
+      // Send back empty packet
       await this.socket.send(PPacket.encode({
-        queryResponse: {
+        channelPacket: {
           channelId: packet.channelId,
-          abbreviatedMessages: [],
-          forwardHash: null,
-          backwardHash: null,
+          seq,
         },
       }).finish());
       return;
     }
 
-    this.debug('query for channel.id=%s', channel.debugId);
-    return await this.getSyncAgent(channel).receiveQuery(packet);
+    if (!packet.box || packet.box.length === 0) {
+      await this.getSyncAgent(channel).receiveEmptyResponse(seq);
+      return;
+    }
+
+    const content = PChannelPacket.Content.decode(
+      channel.decrypt(packet.box, packet.nonce));
+
+    let response;
+    switch (content.content) {
+      case 'query':
+        response = await this.onQuery(channel, seq, content.query);
+        break;
+      case 'queryResponse':
+        response = await this.onQueryResponse(channel, seq,
+          content.queryResponse);
+        break;
+      case 'bulk':
+        response = await this.onBulk(channel, seq, content.bulk);
+        break;
+      case 'bulkResponse':
+        response = await this.onBulkResponse(channel, seq,
+          content.bulkResponse);
+        break;
+      default:
+        throw new BanError(
+          'Unsupported channel packet type: ' + content.content);
+    }
+
+    if (!response) {
+      return;
+    }
+
+    const { box, nonce } = channel.encrypt(response);
+
+    await this.socket.send(PPacket.encode({
+      channelPacket: {
+        channelId: packet.channelId,
+        seq,
+        nonce,
+        box,
+      },
+    }).finish());
   }
 
   /** **(Internal)** */
-  async onQueryResponse(packet) {
-    Channel.checkId(packet.channelId, 'Invalid channelId in QueryResponse');
+  async onQuery(channel, seq, packet) {
+    if (packet.cursor === 'hash') {
+      Message.checkHash(packet.hash, 'Invalid cursor.hash in Query');
+    }
+
+    this.debug('query for channel.id=%s', channel.debugId);
+    return await this.getSyncAgent(channel).receiveQuery(seq, packet);
+  }
+
+  /** **(Internal)** */
+  async onQueryResponse(channel, seq, packet) {
     for (const abbr of packet.abbreviatedMessages) {
       Message.checkHash(abbr.hash, 'Invalid abbreviated message hash');
       for (const hash of abbr.parents) {
@@ -293,52 +333,24 @@ export default class Peer {
       Message.checkHash(packet.backwardHash, 'Invalid backward hash');
     }
 
-    const channel = this.getChannel(packet.channelId);
-    if (!channel) {
-      this.debug('ignoring query response for unknown channel');
-      return;
-    }
-
-    return await this.getSyncAgent(channel).receiveQueryResponse(packet);
+    return await this.getSyncAgent(channel).receiveQueryResponse(seq, packet);
   }
 
   /** **(Internal)** */
-  async onBulk(packet) {
-    Channel.checkId(packet.channelId, 'Invalid channelId in Bulk');
+  async onBulk(channel, seq, packet) {
     for (const hash of packet.hashes) {
       Message.checkHash(hash, 'Invalid message hash in Bulk');
     }
 
-    const channel = this.getChannel(packet.channelId);
-    if (!channel) {
-      this.debug('responding bulk for unknown channel');
-      await this.socket.send(PPacket.encode({
-        bulkResponse: {
-          channelId: packet.channelId,
-          messages: [],
-          forwardIndex: packet.hashes.length,
-        },
-      }).finish());
-      return;
-    }
-
     this.debug('bulk for channel.id=%s hashes.length=%d', channel.debugId,
       packet.hashes.length);
-    return await this.getSyncAgent(channel).receiveBulk(packet);
+    return await this.getSyncAgent(channel).receiveBulk(seq, packet);
   }
 
   /** **(Internal)** */
-  async onBulkResponse(packet) {
-    Channel.checkId(packet.channelId, 'Invalid channelId in BulkResponse');
-
-    const channel = this.getChannel(packet.channelId);
-    if (!channel) {
-      this.debug('ignoring bulk response for unknown channel');
-      return;
-    }
-
+  async onBulkResponse(channel, seq, packet) {
     // NOTE: `Message` constructor will check each message
-    return await this.getSyncAgent(channel).receiveBulkResponse(packet);
+    return await this.getSyncAgent(channel).receiveBulkResponse(seq, packet);
   }
 
   /** **(Internal)** */

--- a/lib/peer.js
+++ b/lib/peer.js
@@ -270,9 +270,20 @@ export default class Peer {
       return;
     }
 
-    const chain = Chain.deserialize(packet.chain, { sodium: this.sodium });
-    if (!chain.verify(channel)) {
-      throw new BanError('Invalid SyncRequest chain');
+    let leafKey;
+    if (channel.isFeed) {
+      if (packet.identity !== 'publicKey') {
+        throw new BanError('Expected publicKey in SyncRequest for a feed');
+      }
+      leafKey = packet.publicKey;
+    } else {
+      if (packet.identity !== 'chain') {
+        throw new BanError('Expected chain in SyncRequest for a channel');
+      }
+
+      const chain = Chain.deserialize(packet.chain.links,
+        { sodium: this.sodium });
+      leafKey = chain.getLeafKey(channel);
     }
 
     const content = PSyncRequest.Content.decode(
@@ -295,7 +306,6 @@ export default class Peer {
       throw Error('Internal error: missing response');
     }
 
-    const leafKey = chain.getLeafKey(channel);
     const encoded = PSyncResponse.Content.encode(response).finish();
 
     const box = Identity.encryptFor(leafKey, encoded, { sodium: this.sodium });

--- a/lib/peer.js
+++ b/lib/peer.js
@@ -423,6 +423,8 @@ export default class Peer {
     this.getSyncAgent(channel).synchronize().catch((e) => {
       this.debug('channel.id=%s sync error.message=%s', channel.debugId,
         e.stack);
+
+      this.destroy(e).catch((_) => {});
     });
   }
 

--- a/lib/peer.js
+++ b/lib/peer.js
@@ -1,6 +1,7 @@
 import createDebug from 'debug';
 import WaitList from 'promise-waitlist';
 
+import Chain from './protocol/chain';
 import Channel from './protocol/channel';
 import Identity from './protocol/identity';
 import Message from './protocol/message';
@@ -8,7 +9,8 @@ import {
   Hello as PHello,
   Shake as PShake,
   Packet as PPacket,
-  ChannelPacket as PChannelPacket,
+  SyncRequest as PSyncRequest,
+  SyncResponse as PSyncResponse,
 } from './messages';
 import SyncAgent from './sync-agent';
 import { compareDistance, BanError } from './utils';
@@ -31,6 +33,7 @@ export default class Peer {
       localId,
       socket,
       globalPeerIds = new Set(),
+      identities = [],
       channels = [],
       inviteWaitList = new WaitList(),
     } = options;
@@ -56,6 +59,7 @@ export default class Peer {
     this.socket = socket;
 
     this.globalPeerIds = globalPeerIds;
+    this.identities = identities;
     this.channels = channels;
     this.inviteWaitList = inviteWaitList;
 
@@ -144,8 +148,11 @@ export default class Peer {
         case 'invite':
           await this.onInvite(packet.invite);
           break;
-        case 'channelPacket':
-          await this.onChannelPacket(packet.channelPacket);
+        case 'syncRequest':
+          await this.onSyncRequest(packet.syncRequest);
+          break;
+        case 'syncResponse':
+          await this.onSyncResponse(packet.syncResponse);
           break;
         case 'notification':
           await this.onNotification(packet.notification);
@@ -245,13 +252,13 @@ export default class Peer {
   }
 
   /** **(Internal)** */
-  async onChannelPacket(packet) {
-    Channel.checkId(packet.channelId, 'Invalid channelId in ChannelPacket');
+  async onSyncRequest(packet) {
+    Channel.checkId(packet.channelId, 'Invalid channelId in SyncRequest');
     const channel = this.getChannel(packet.channelId);
     const seq = packet.seq;
 
     if (!channel) {
-      this.debug('responding to channel packet for unknown channel');
+      this.debug('responding to sync request packet for unknown channel');
 
       // Send back empty packet
       await this.socket.send(PPacket.encode({
@@ -268,7 +275,12 @@ export default class Peer {
       return;
     }
 
-    const content = PChannelPacket.Content.decode(
+    const chain = Chain.deserialize(packet.chain);
+    if (!chain.verify(this.channel)) {
+      throw new BanError('Invalid SyncRequest chain');
+    }
+
+    const content = PSyncRequest.Content.decode(
       channel.decrypt(packet.box, packet.nonce));
 
     let response;
@@ -276,36 +288,61 @@ export default class Peer {
       case 'query':
         response = await this.onQuery(channel, seq, content.query);
         break;
-      case 'queryResponse':
-        response = await this.onQueryResponse(channel, seq,
-          content.queryResponse);
-        break;
       case 'bulk':
         response = await this.onBulk(channel, seq, content.bulk);
         break;
-      case 'bulkResponse':
-        response = await this.onBulkResponse(channel, seq,
-          content.bulkResponse);
-        break;
       default:
         throw new BanError(
-          'Unsupported channel packet type: ' + content.content);
+          'Unsupported sync request type: ' + content.content);
     }
 
     if (!response) {
-      return;
+      throw Error('Internal error: missing response');
     }
 
-    const { box, nonce } = channel.encrypt(response);
+    const leafKey = chain.getLeafKey();
+    const encoded = PSyncResponse.Content.encode(response).finish();
+
+    const box = Identity.encryptFor(leafKey, encoded, { sodium: this.sodium });
 
     await this.socket.send(PPacket.encode({
-      channelPacket: {
+      syncResponse: {
         channelId: packet.channelId,
         seq,
-        nonce,
         box,
       },
     }).finish());
+  }
+
+  async onSyncResponse(packet) {
+    Channel.checkId(packet.channelId, 'Invalid channelId in SyncResponse');
+    const channel = this.getChannel(packet.channelId);
+    const seq = packet.seq;
+
+    if (!channel) {
+      this.debug('sync response to unknown channel, ignoring');
+      return;
+    }
+
+    const agent = this.getSyncAgent(channel);
+    const identity = agent.getRequestingIdentity(seq);
+    if (!identity) {
+      throw new BanError('Unknown sequence id in SyncResponse');
+    }
+
+    const content = PSyncResponse.Content.decode(identity.decrypt(packet.box));
+
+    switch (content.content) {
+      case 'queryResponse':
+        await this.onQueryResponse(channel, seq, content.queryResponse);
+        break;
+      case 'bulkResponse':
+        await this.onBulkResponse(channel, seq, content.bulkResponse);
+        break;
+      default:
+        throw new BanError(
+          'Unsupported sync response content type: ' + content.content);
+    }
   }
 
   /** **(Internal)** */
@@ -397,9 +434,11 @@ export default class Peer {
       agent = this.syncAgents.get(channel);
     } else {
       agent = new SyncAgent({
-        channel,
-        socket: this.socket,
         sodium: this.sodium,
+
+        channel,
+        identities: this.identities,
+        socket: this.socket,
       });
       this.syncAgents.set(channel, agent);
     }

--- a/lib/protocol.js
+++ b/lib/protocol.js
@@ -372,6 +372,7 @@ export default class Protocol {
       ...options,
       sodium: this.sodium,
       storage: this.storage,
+      isFeed: true,
     };
     const channel = await Channel.fromPublicKey(publicKey, options);
 

--- a/lib/protocol.js
+++ b/lib/protocol.js
@@ -367,7 +367,7 @@ export default class Protocol {
     return await this.addChannel(channel);
   }
 
-  async channelFromPublicKey(publicKey, options) {
+  async feedFromPublicKey(publicKey, options) {
     options = {
       ...options,
       sodium: this.sodium,

--- a/lib/protocol.js
+++ b/lib/protocol.js
@@ -287,10 +287,12 @@ export default class Protocol {
    * @returns {Promise} A Promise with a tuple of newly created Identity and
    *   Channel
    */
-  async createIdentityPair(name) {
+  async createIdentityPair(name, options) {
     const identity = new Identity(name, { sodium: this.sodium });
 
     const channel = await Channel.fromIdentity(identity, {
+      ...options,
+
       name: identity.name,
       sodium: this.sodium,
       storage: this.storage,

--- a/lib/protocol.js
+++ b/lib/protocol.js
@@ -441,6 +441,7 @@ export default class Protocol {
       socket,
       sodium: this.sodium,
       globalPeerIds: this.globalPeerIds,
+      identities: this.identities,
       channels: this.channels,
       inviteWaitList: this.inviteWaitList,
     });

--- a/lib/protocol/cache.js
+++ b/lib/protocol/cache.js
@@ -1,3 +1,5 @@
+import { Buffer } from 'buffer';
+
 import LRU from 'quick-lru';
 import createDebug from 'debug';
 
@@ -15,19 +17,19 @@ export default class StorageCache {
     };
 
     this.sodium = options.sodium;
-    this.channelId = options.channelId;
+    this.channel = options.channel;
     this.backend = options.backend;
     if (!this.sodium) {
       throw new Error('Missing required `sodium` option');
     }
-    if (!this.channelId) {
-      throw new Error('Missing required `channelId` option');
+    if (!this.channel) {
+      throw new Error('Missing required `channel` option');
     }
     if (!this.backend) {
       throw new Error('Missing required `backend` option');
     }
 
-    this.debugId = this.channelId.toString('hex').slice(0, 8);
+    this.debugId = this.channel.id.toString('hex').slice(0, 8);
 
     this.lru = new LRU({ maxSize: options.maxLRUSize });
 
@@ -36,12 +38,14 @@ export default class StorageCache {
   }
 
   async addMessage(message) {
+    const { nonce, box } = this.channel.encrypt(message.serializeData());
+
     const result = await this.backend.addMessage({
-      channelId: this.channelId,
+      channelId: this.channel.id,
       hash: message.hash,
       parents: message.parents,
       height: message.height,
-      data: message.serializeData(),
+      data: Buffer.concat([ nonce, box ]),
     });
 
     // Invalidate caches
@@ -57,7 +61,7 @@ export default class StorageCache {
   async getMessageCount() {
     if (this.lastCount === null) {
       this.debug('message count miss');
-      this.lastCount = await this.backend.getMessageCount(this.channelId);
+      this.lastCount = await this.backend.getMessageCount(this.channel.id);
     } else {
       this.debug('message count hit %d', this.lastCount);
     }
@@ -67,7 +71,7 @@ export default class StorageCache {
   async getLeaves() {
     if (this.leaves === null) {
       this.debug('getLeaves() miss');
-      const leafHashes = await this.backend.getLeafHashes(this.channelId);
+      const leafHashes = await this.backend.getLeafHashes(this.channel.id);
       this.leaves = await this.getMessages(leafHashes);
     } else {
       this.debug('getLeaves() hit');
@@ -81,7 +85,7 @@ export default class StorageCache {
       return true;
     }
     this.debug('hasMessage() miss');
-    return await this.backend.hasMessage(this.channelId, hash);
+    return await this.backend.hasMessage(this.channel.id, hash);
   }
 
   async getMessage(hash) {
@@ -93,8 +97,8 @@ export default class StorageCache {
     }
 
     this.debug('getMessage() miss');
-    const data = await this.backend.getMessage(this.channelId, hash);
-    const message = Message.deserializeData(data, { sodium: this.sodium });
+    const data = await this.backend.getMessage(this.channel.id, hash);
+    const message = this.deserializeMessage(data);
     this.lru.set(cacheKey, message);
     return message;
   }
@@ -114,13 +118,13 @@ export default class StorageCache {
     this.debug('getMessages() hit=%d miss=%d',
       hashes.length - missing.length, missing.length);
 
-    const fetched = await this.backend.getMessages(this.channelId,
+    const fetched = await this.backend.getMessages(this.channel.id,
       missing.map((entry) => entry.hash));
     for (const [ i, data ] of fetched.entries()) {
       if (!data) {
         continue;
       }
-      const message = Message.deserializeData(data, { sodium: this.sodium });
+      const message = this.deserializeMessage(data);
       result[missing[i].index] = message;
 
       this.lru.set(message.hash.toString('hex'), message);
@@ -130,24 +134,24 @@ export default class StorageCache {
 
   async getMessagesAtOffset(offset, limit) {
     const hashes = await this.backend.getHashesAtOffset(
-      this.channelId, offset, limit);
+      this.channel.id, offset, limit);
     return await this.getMessages(hashes);
   }
 
   async getReverseMessagesAtOffset(offset, limit) {
     const hashes = await this.backend.getReverseHashesAtOffset(
-      this.channelId, offset, limit);
+      this.channel.id, offset, limit);
     return await this.getMessages(hashes);
   }
 
   async query(...args) {
-    return await this.backend.query(this.channelId, ...args);
+    return await this.backend.query(this.channel.id, ...args);
   }
 
-  async removeChannelMessages(channelId) {
+  async removeChannelMessages() {
     // NOTE: We do not need to invalidate LRU since `Cache` is already per
     // Channel.
-    await this.backend.removeChannelMessages(channelId);
+    await this.backend.removeChannelMessages(this.channel.id);
   }
 
   //
@@ -180,6 +184,15 @@ export default class StorageCache {
   //
   // Internal
   //
+
+  deserializeMessage(box) {
+    const nonce = box.slice(0, this.sodium.crypto_secretbox_NONCEBYTES);
+    box = box.slice(nonce.length);
+
+    const data = this.channel.decrypt(box, nonce);
+
+    return Message.deserializeData(data, { sodium: this.sodium });
+  }
 
   debug(fmt, ...args) {
     return debug('[%s] ' + fmt, ...[ this.debugId ].concat(args));

--- a/lib/protocol/chain.js
+++ b/lib/protocol/chain.js
@@ -11,6 +11,8 @@ export default class Chain {
     if (this.links.length > MAX_LENGTH) {
       throw new BanError(`Chain length overflow: ${this.links.length}`);
     }
+
+    this.length = this.links.length;
   }
 
   getLeafKey(channel, timestamp = now()) {

--- a/lib/protocol/channel.js
+++ b/lib/protocol/channel.js
@@ -116,10 +116,9 @@ export default class Channel {
       height: 0,
     });
     const root = new Message({
-      sodium: channel.sodium,
+      ...content,
 
-      channel,
-      content,
+      sodium: channel.sodium,
     });
 
     await channel.receive(root);
@@ -198,10 +197,9 @@ export default class Channel {
     Channel.checkJSONLimit(body.json, content.chain.length);
 
     const message = new Message({
-      sodium: this.sodium,
+      ...content,
 
-      channel: this,
-      content,
+      sodium: this.sodium,
     });
 
     await this.cache.addMessage(message);
@@ -219,8 +217,6 @@ export default class Channel {
       this.debug('received duplicate hash=%s', message.debugHash);
       return;
     }
-
-    message.decrypt(this);
 
     //
     // Verify signature
@@ -263,28 +259,27 @@ export default class Channel {
     //
 
     const future = now() + FUTURE;
-    if (message.content.timestamp > future) {
+    if (message.timestamp > future) {
       throw new BanError('Received message is in the future');
     }
 
     const parentTimestamp = this.computeMaxTimestamp(parents);
-    if (message.content.timestamp < parentTimestamp) {
+    if (message.timestamp < parentTimestamp) {
       throw new BanError('Received message is in the past');
     }
 
     if (parents.length === 0) {
-      if (!message.content.body.root) {
+      if (!message.body.root) {
         throw new BanError('Invalid root content');
       }
     }
 
     if (parents.length !== 0) {
-      if (message.content.body.root) {
+      if (message.body.root) {
         throw new BanError('Invalid non-root content');
       }
 
-      Channel.checkJSONLimit(message.content.body.json,
-        message.content.chain.length);
+      Channel.checkJSONLimit(message.body.json, message.chain.length);
     }
 
     await this.cache.addMessage(message);
@@ -299,49 +294,24 @@ export default class Channel {
   }
 
   async getMessagesAtOffset(offset, limit = 1) {
-    const messages = await this.cache.getMessagesAtOffset(offset, limit);
-    return messages.map((message) => {
-      message.decrypt(this);
-      return message;
-    });
+    return await this.cache.getMessagesAtOffset(offset, limit);
   }
 
   async getReverseMessagesAtOffset(offset, limit = 1) {
-    const messages = await this.cache.getReverseMessagesAtOffset(
-      offset, limit);
-    return messages.map((message) => {
-      message.decrypt(this);
-      return message;
-    });
-  }
-
-  async getEncryptedLeaves() {
-    return await this.cache.getLeaves();
+    return await this.cache.getReverseMessagesAtOffset(offset, limit);
   }
 
   async getLeaves() {
-    let leaves = await this.getEncryptedLeaves();
-    leaves = leaves.slice(0, MAX_LEAVES_COUNT);
-
-    return leaves.map((leaf) => {
-      leaf.decrypt(this);
-      return leaf;
-    });
+    const leaves = await this.cache.getLeaves();
+    return leaves.slice(0, MAX_LEAVES_COUNT);
   }
 
   async getMessages(hashes) {
-    const messages = await this.cache.getMessages(hashes);
-
-    return messages.map((message) => {
-      if (message) {
-        message.decrypt(this);
-      }
-      return message;
-    })
+    return await this.cache.getMessages(hashes);
   }
 
   async getMinLeafHeight() {
-    const leaves = await this.getEncryptedLeaves();
+    const leaves = await this.getLeaves();
     return leaves.reduce((acc, leave) => {
       return Math.min(acc, leave.height);
     }, Number.MAX_SAFE_INTEGER);
@@ -446,6 +416,9 @@ export default class Channel {
       const expected = new Set(known.map((hash) => hash.toString('hex')));
       while (known.length !== 0) {
         const { messages, forwardIndex } = await remote.bulk(known);
+        if (forwardIndex <= 0) {
+          throw new BanError('Failed to make progress');
+        }
 
         for (const message of messages) {
           const hexHash = message.hash.toString('hex');
@@ -503,13 +476,13 @@ export default class Channel {
 
   adjustTimestamp(parents, timestamp) {
     return parents.reduce((acc, parent) => {
-      return Math.max(acc, parent.content.timestamp);
+      return Math.max(acc, parent.timestamp);
     }, timestamp);
   }
 
   computeMaxTimestamp(parents) {
     return parents.reduce((acc, parent) => {
-      return Math.max(acc, parent.content.timestamp);
+      return Math.max(acc, parent.timestamp);
     }, 0);
   }
 
@@ -518,7 +491,7 @@ export default class Channel {
     const min = max - MAX_PARENT_DELTA;
 
     return parents.filter((parent) => {
-      return parent.content.timestamp >= min;
+      return parent.timestamp >= min;
     });
   }
 

--- a/lib/protocol/channel.js
+++ b/lib/protocol/channel.js
@@ -116,6 +116,7 @@ export default class Channel {
     const content = identity.signMessageBody(Message.root(), channel, {
       parents: [],
       height: 0,
+      timestamp: options.timestamp || now(),
     });
     const root = new Message({
       ...content,

--- a/lib/protocol/channel.js
+++ b/lib/protocol/channel.js
@@ -61,7 +61,11 @@ export default class Channel {
 
     this.cache = new StorageCache({
       sodium,
-      channelId: this.id,
+
+      // NOTE: Not my favorite "pattern", but it is better than passing
+      // encryption keys to it
+      channel: this,
+
       backend: this.options.storage || new MemoryStorage(),
       ...(this.options.cache || {}),
     });

--- a/lib/protocol/channel.js
+++ b/lib/protocol/channel.js
@@ -119,8 +119,6 @@ export default class Channel {
       sodium: channel.sodium,
 
       channel,
-      parents: [],
-      height: 0,
       content,
     });
 
@@ -203,8 +201,6 @@ export default class Channel {
       sodium: this.sodium,
 
       channel: this,
-      parents: parentHashes,
-      height,
       content,
     });
 

--- a/lib/protocol/channel.js
+++ b/lib/protocol/channel.js
@@ -22,6 +22,8 @@ export const MAX_LEAVES_COUNT = 128;
 const ID_KEY = Buffer.from('vowlink-channel-id');
 const ENC_KEY = Buffer.from('vowlink-symmetric');
 
+const kEncryptionKey = Symbol('encryptionKey');
+
 const FUTURE = 2 * 60; // 2 minutes
 
 export default class Channel {
@@ -53,8 +55,8 @@ export default class Channel {
 
     this.debugId = this.id.toString('hex').slice(0, 8) + '/' + this.name;
 
-    this.encryptionKey = Buffer.alloc(sodium.crypto_secretbox_KEYBYTES);
-    sodium.crypto_generichash(this.encryptionKey, this.publicKey, ENC_KEY);
+    this[kEncryptionKey] = Buffer.alloc(sodium.crypto_secretbox_KEYBYTES);
+    sodium.crypto_generichash(this[kEncryptionKey], this.publicKey, ENC_KEY);
 
     this.cache = new StorageCache({
       sodium,
@@ -77,9 +79,9 @@ export default class Channel {
     const sodium = this.sodium;
 
     if (sodium.sodium_memzero) {
-      sodium.sodium_memzero(this.encryptionKey);
+      sodium.sodium_memzero(this[kEncryptionKey]);
     } else {
-      this.encryptionKey.fill(0);
+      this[kEncryptionKey].fill(0);
     }
 
     this.waitList.close(new Error('Closed'));
@@ -464,6 +466,39 @@ export default class Channel {
     this.debug('completed sync to remote isFull=%j', isFull);
   }
 
+  encrypt(data) {
+    const sodium = this.sodium;
+
+    const nonce = Buffer.alloc(sodium.crypto_secretbox_NONCEBYTES);
+    sodium.randombytes_buf(nonce);
+
+    const box = Buffer.alloc(data.length + sodium.crypto_secretbox_MACBYTES);
+    sodium.crypto_secretbox_easy(box, data, nonce, this[kEncryptionKey]);
+
+    return { nonce, box };
+  }
+
+  decrypt(box, nonce) {
+    const sodium = this.sodium;
+
+    if (nonce.length !== sodium.crypto_secretbox_NONCEBYTES) {
+      throw new BanError('Invalid nonce');
+    }
+    if (box.length <= sodium.crypto_secretbox_MACBYTES) {
+      throw new BanError('Invalid encrypted box');
+    }
+
+    const data = Buffer.alloc(box.length - sodium.crypto_secretbox_MACBYTES);
+    const isSuccess = sodium.crypto_secretbox_open_easy(
+      data, box, nonce, this[kEncryptionKey]);
+
+    if (!isSuccess) {
+      throw new BanError('Invalid encrypted box');
+    }
+
+    return data;
+  }
+
   //
   // Private
   //
@@ -597,7 +632,7 @@ export default class Channel {
   }
 
   static checkId(id, message) {
-    if (id.length !== ID_SIZE) {
+    if (!id || id.length !== ID_SIZE) {
       throw new BanError(message);
     }
   }

--- a/lib/protocol/channel.js
+++ b/lib/protocol/channel.js
@@ -36,6 +36,7 @@ export default class Channel {
     };
     this.name = this.options.name;
     this.publicKey = this.options.publicKey;
+    this.isFeed = !!this.options.isFeed;
     this.sodium = this.options.sodium;
 
     if (!this.sodium) {
@@ -593,6 +594,7 @@ export default class Channel {
     return {
       publicKey: this.publicKey,
       name: this.name,
+      isFeed: this.isFeed,
 
       metadata: this.metadata ? JSON.stringify(this.metadata) : '',
     };
@@ -607,6 +609,7 @@ export default class Channel {
       ...options,
       name: decoded.name,
       publicKey: decoded.publicKey,
+      isFeed: decoded.isFeed,
     });
     if (decoded.metadata) {
       try {

--- a/lib/protocol/identity.js
+++ b/lib/protocol/identity.js
@@ -129,7 +129,18 @@ export default class Identity {
   }
 
   getChain(channel) {
-    return this.chains.get(channel.id.toString('hex'));
+    const chain = this.chains.get(channel.id.toString('hex'));
+    if (!chain) {
+      return;
+    }
+
+    // Purge invalid chains
+    if (!chain.isValid()) {
+      this.removeChain(channel);
+      return;
+    }
+
+    return chain;
   }
 
   removeChain(channel) {
@@ -203,50 +214,31 @@ export default class Identity {
   requestInvite(peerId) {
     const sodium = this.sodium;
 
-    const boxPubKey = Buffer.alloc(sodium.crypto_box_PUBLICKEYBYTES);
-    const boxSecretKey = Buffer.alloc(sodium.crypto_box_SECRETKEYBYTES);
-
-    // TODO(indutny): implement it in `sodium-javascript`
-    sodium.crypto_sign_ed25519_pk_to_curve25519(boxPubKey, this.publicKey);
-    sodium.crypto_sign_ed25519_sk_to_curve25519(boxSecretKey, this[kSecretKey]);
-
     const request = PInviteRequest.encode({
       peerId,
       trusteePubKey: this.publicKey,
     }).finish();
 
-
     const requestId = this.inviteRequestIdFor(this.publicKey);
 
     const decrypt = (encrypted) => {
       if (encrypted.requestId.length !== INVITE_REQUEST_ID_LENGTH) {
-        throw new Error('Invalid invite request id length');
+        throw new BanError('Invalid invite request id length');
       }
       if (!encrypted.requestId.equals(requestId)) {
-        throw new Error('Invalid invite request id');
+        throw new BanError('Invalid invite request id');
       }
 
-      const cleartext = Buffer.alloc(
-        encrypted.box.length - sodium.crypto_box_SEALBYTES);
-
-      // TODO(indutny): implement it in `sodium-javascript`
-      // https://github.com/sodium-friends/sodium-javascript/pull/16
-      const isSuccess = sodium.crypto_box_seal_open(
-        cleartext, encrypted.box, boxPubKey, boxSecretKey);
-
-      if (!isSuccess) {
-        throw new Error('Invalid encrypted invite. Failed to decrypt');
-      }
-
+      const cleartext = this.decrypt(encrypted.box);
       const invite = PInvite.decode(cleartext);
 
       if (invite.channelName.length > MAX_INVITE_NAME_LENGTH) {
-        throw new Error('Invalid invite channel name length: ' +
+        throw new BanError('Invalid invite channel name length: ' +
           invite.channelName.length);
       }
 
       if (invite.channelPubKey.length !== sodium.crypto_sign_PUBLICKEYBYTES) {
-        throw new Error('Invalid invite channel public key length: ' +
+        throw new BanError('Invalid invite channel public key length: ' +
           invite.channelPubKey.length);
       }
 
@@ -277,10 +269,10 @@ export default class Identity {
     const request = PInviteRequest.decode(requestData);
 
     if (request.trusteePubKey.length !== sodium.crypto_sign_PUBLICKEYBYTES) {
-      throw new Error('Invalid `trusteePubKey` length');
+      throw new BanError('Invalid `trusteePubKey` length');
     }
     if (request.peerId.length > Peer.ID_LENGTH) {
-      throw new Error('Invalid `peerId` length');
+      throw new BanError('Invalid `peerId` length');
     }
 
     if (!this.canPost(channel)) {
@@ -310,24 +302,64 @@ export default class Identity {
     const ciphertext = Buffer.alloc(
       invite.length + sodium.crypto_box_SEALBYTES);
 
-    // TODO(indutny): implement it in `sodium-javascript`
-    const boxPubKey = Buffer.alloc(sodium.crypto_box_PUBLICKEYBYTES);
-    sodium.crypto_sign_ed25519_pk_to_curve25519(
-      boxPubKey, request.trusteePubKey);
-
-    // TODO(indutny): implement it in `sodium-javascript`
-    // https://github.com/sodium-friends/sodium-javascript/pull/16
-    sodium.crypto_box_seal(ciphertext, invite, boxPubKey);
+    const box = Identity.encryptFor(request.trusteePubKey, invite, {
+      sodium,
+    });
 
     const requestId = this.inviteRequestIdFor(request.trusteePubKey);
 
     return {
       encryptedInvite: {
         requestId,
-        box: ciphertext,
+        box,
       },
       peerId: request.peerId,
     };
+  }
+
+  static encryptFor(publicKey, data, options) {
+    const { sodium } = options;
+    if (!sodium) {
+      throw new Error('Missing required `sodium` option');
+    }
+
+    // TODO(indutny): implement it in `sodium-javascript`
+    const boxPubKey = Buffer.alloc(sodium.crypto_box_PUBLICKEYBYTES);
+    sodium.crypto_sign_ed25519_pk_to_curve25519(boxPubKey, publicKey);
+
+    // TODO(indutny): implement it in `sodium-javascript`
+    // https://github.com/sodium-friends/sodium-javascript/pull/16
+    const box = Buffer.alloc(
+      data.length + sodium.crypto_box_SEALBYTES);
+    sodium.crypto_box_seal(box, data, boxPubKey);
+    return box;
+  }
+
+  decrypt(box) {
+    const sodium = this.sodium;
+
+    const boxPubKey = Buffer.alloc(sodium.crypto_box_PUBLICKEYBYTES);
+    const boxSecretKey = Buffer.alloc(sodium.crypto_box_SECRETKEYBYTES);
+
+    // TODO(indutny): implement it in `sodium-javascript`
+    sodium.crypto_sign_ed25519_pk_to_curve25519(boxPubKey, this.publicKey);
+    sodium.crypto_sign_ed25519_sk_to_curve25519(boxSecretKey, this[kSecretKey]);
+
+    if (box.length <= sodium.crypto_box_SEALBYTES) {
+      throw new BanError('Invalid encrypted box length');
+    }
+    const cleartext = Buffer.alloc(box.length - sodium.crypto_box_SEALBYTES);
+
+    // TODO(indutny): implement it in `sodium-javascript`
+    // https://github.com/sodium-friends/sodium-javascript/pull/16
+    const isSuccess = sodium.crypto_box_seal_open(
+      cleartext, box, boxPubKey, boxSecretKey);
+
+    if (!isSuccess) {
+      throw new BanError('Invalid encrypted box. Failed to decrypt');
+    }
+
+    return cleartext;
   }
 
   // Internal

--- a/lib/protocol/identity.js
+++ b/lib/protocol/identity.js
@@ -189,7 +189,7 @@ export default class Identity {
     return {
       parents,
       height,
-      chain: chain.serialize(),
+      chain,
       timestamp,
       body,
       signature,

--- a/lib/protocol/identity.js
+++ b/lib/protocol/identity.js
@@ -128,16 +128,15 @@ export default class Identity {
     this.chains.set(key, chain);
   }
 
-  getChain(channel) {
+  getChain(channel, timestamp = now()) {
     const chain = this.chains.get(channel.id.toString('hex'));
     if (!chain) {
       return;
     }
 
     // Purge invalid chains
-    if (!chain.isValid()) {
-      this.removeChain(channel);
-      return;
+    if (!chain.isValid(timestamp + LINK_EXPIRATION_LEEWAY)) {
+      return false;
     }
 
     return chain;
@@ -152,10 +151,10 @@ export default class Identity {
     return true;
   }
 
-  getChannelIds() {
+  getChannelIds(timestamp = now()) {
     const result = [];
     for (const [ key, chain ] of this.chains) {
-      if (chain.isValid()) {
+      if (chain.isValid(timestamp + LINK_EXPIRATION_LEEWAY)) {
         result.push(Buffer.from(key, 'hex'));
       }
     }

--- a/lib/protocol/identity.js
+++ b/lib/protocol/identity.js
@@ -187,6 +187,8 @@ export default class Identity {
     sodium.crypto_sign_detached(signature, tbs, this[kSecretKey]);
 
     return {
+      parents,
+      height,
       chain: chain.serialize(),
       timestamp,
       body,

--- a/lib/protocol/identity.js
+++ b/lib/protocol/identity.js
@@ -1,7 +1,7 @@
 import { Buffer } from 'buffer';
 import createDebug from 'debug';
 
-import { now } from '../utils';
+import { now, BanError } from '../utils';
 import {
   Identity as PIdentity,
   Invite as PInvite,
@@ -345,7 +345,7 @@ export default class Identity {
     sodium.crypto_sign_ed25519_pk_to_curve25519(boxPubKey, this.publicKey);
     sodium.crypto_sign_ed25519_sk_to_curve25519(boxSecretKey, this[kSecretKey]);
 
-    if (box.length <= sodium.crypto_box_SEALBYTES) {
+    if (box.length < sodium.crypto_box_SEALBYTES) {
       throw new BanError('Invalid encrypted box length');
     }
     const cleartext = Buffer.alloc(box.length - sodium.crypto_box_SEALBYTES);

--- a/lib/protocol/identity.js
+++ b/lib/protocol/identity.js
@@ -299,9 +299,6 @@ export default class Identity {
       chain: inviteChain.serialize(),
     }).finish();
 
-    const ciphertext = Buffer.alloc(
-      invite.length + sodium.crypto_box_SEALBYTES);
-
     const box = Identity.encryptFor(request.trusteePubKey, invite, {
       sodium,
     });
@@ -321,6 +318,10 @@ export default class Identity {
     const { sodium } = options;
     if (!sodium) {
       throw new Error('Missing required `sodium` option');
+    }
+
+    if (publicKey.length !== sodium.crypto_sign_PUBLICKEYBYTES) {
+      throw new BanError('Invalid public key length');
     }
 
     // TODO(indutny): implement it in `sodium-javascript`

--- a/lib/protocol/link.js
+++ b/lib/protocol/link.js
@@ -29,6 +29,12 @@ export default class Link {
       throw new BanError('Invalid trusteeDisplayName length: ' +
         trusteeDisplayName.length);
     }
+    if (signature.length !== sodium.crypto_sign_BYTES) {
+      throw new BanError('Invalid signature length');
+    }
+    if (trusteePubKey.length !== sodium.crypto_sign_PUBLICKEYBYTES) {
+      throw new BanError('Invalid public key length');
+    }
 
     this.sodium = sodium;
 

--- a/lib/protocol/message.js
+++ b/lib/protocol/message.js
@@ -105,7 +105,7 @@ export default class Message {
   }
 
   static deserialize(decoded, options) {
-    const chain = Chain.deserialize(decoded.tbs.chain);
+    const chain = Chain.deserialize(decoded.tbs.chain, options);
 
     return new Message({
       sodium: options.sodium,

--- a/lib/protocol/message.js
+++ b/lib/protocol/message.js
@@ -3,7 +3,6 @@ import { Buffer } from 'buffer';
 import { ChannelMessage as PChannelMessage } from '../messages';
 import { BanError } from '../utils';
 
-import Channel from './channel';
 import Chain from './chain';
 import Link from './link';
 
@@ -14,14 +13,10 @@ export default class Message {
   constructor(options) {
     const {
       // NOTE: `channel` MUST be supplied with `content`
-      // `channelId` MAY be supplied instead for `encryptedContent`
       channel,
-      channelId,
 
       sodium,
 
-      parents,
-      height,
       nonce,
       content,
       encryptedContent,
@@ -33,9 +28,6 @@ export default class Message {
 
     this.sodium = sodium;
 
-    this.channelId = channelId || channel.id;
-    this.parents = parents;
-    this.height = height;
     this.nonce = nonce;
 
     if (!this.nonce) {
@@ -43,13 +35,6 @@ export default class Message {
       sodium.randombytes_buf(this.nonce);
     }
 
-    Channel.checkId(this.channelId, 'Invalid channel id size');
-    this.parents.forEach((hash) => {
-      Message.checkHash(hash, 'Invalid parent hash');
-    });
-    if (this.height < 0) {
-      throw new BanError('Invalid height');
-    }
     if (this.nonce.length !== sodium.crypto_secretbox_NONCEBYTES) {
       throw new BanError('Invalid nonce size');
     }
@@ -124,6 +109,24 @@ export default class Message {
     return this.cachedJSON;
   }
 
+  get parents() {
+    if (!this.content) {
+      throw new Error('Message has not been decrypted');
+    }
+
+    return this.content.parents;
+  }
+
+  get height() {
+    if (!this.content) {
+      throw new Error('Message has not been decrypted');
+    }
+
+    // NOTE: Convert Long to Number
+    return typeof this.content.height === 'number' ?
+      this.content.height : this.content.height.toNumber();
+  }
+
   encrypt(channel) {
     if (this.encryptedContent) {
       return;
@@ -159,6 +162,13 @@ export default class Message {
       throw new BanError('Failed to decrypt message content');
     }
     this.content = PChannelMessage.Content.decode(cleartext);
+
+    this.parents.forEach((hash) => {
+      Message.checkHash(hash, 'Invalid parent hash');
+    });
+    if (this.height < 0) {
+      throw new BanError('Invalid height');
+    }
 
     if (!this.content.body.root) {
       try {
@@ -200,9 +210,6 @@ export default class Message {
     }
 
     return {
-      channelId: this.channelId,
-      parents: this.parents,
-      height: this.height,
       nonce: this.nonce,
       encryptedContent: this.encryptedContent,
     };
@@ -215,11 +222,6 @@ export default class Message {
   static deserialize(decoded, options) {
     return new Message({
       sodium: options.sodium,
-      channelId: decoded.channelId,
-
-      parents: decoded.parents,
-      // NOTE: 53bits of precision is more than enough
-      height: decoded.height.toNumber(),
       nonce: decoded.nonce,
       encryptedContent: decoded.encryptedContent,
     });

--- a/lib/protocol/message.js
+++ b/lib/protocol/message.js
@@ -136,7 +136,7 @@ export default class Message {
   }
 
   static checkHash(hash, message) {
-    if (hash.length !== HASH_SIZE) {
+    if (!hash || hash.length !== HASH_SIZE) {
       throw new BanError(message);
     }
   }

--- a/lib/protocol/message.js
+++ b/lib/protocol/message.js
@@ -1,67 +1,48 @@
 import { Buffer } from 'buffer';
 
 import { ChannelMessage as PChannelMessage } from '../messages';
-import { BanError } from '../utils';
+import { BanError, now } from '../utils';
 
 import Chain from './chain';
 import Link from './link';
 
 export const HASH_SIZE = 32;
-const ENC_KEY = Buffer.from('vowlink-symmetric');
 
 export default class Message {
   constructor(options) {
     const {
-      // NOTE: `channel` MUST be supplied with `content`
-      channel,
-
-      sodium,
-
-      nonce,
-      content,
-      encryptedContent,
+      sodium, parents, height, chain, timestamp = now(), body, signature,
     } = options;
-
     if (!sodium) {
       throw new Error('Missing required `sodium` option');
     }
 
     this.sodium = sodium;
 
-    this.nonce = nonce;
-
-    if (!this.nonce) {
-      this.nonce = Buffer.alloc(sodium.crypto_secretbox_NONCEBYTES);
-      sodium.randombytes_buf(this.nonce);
+    parents.forEach((hash) => {
+      Message.checkHash(hash, 'Invalid parent hash');
+    });
+    if (height < 0) {
+      throw new BanError('Invalid height');
+    }
+    if (signature.length !== sodium.crypto_sign_BYTES) {
+      throw new BanError('Invalid signature length');
+    }
+    if (!body.root) {
+      try {
+        JSON.parse(body.json);
+      } catch (e) {
+        throw new BanError('Invalid JSON content. ' + e.message);
+      }
     }
 
-    if (this.nonce.length !== sodium.crypto_secretbox_NONCEBYTES) {
-      throw new BanError('Invalid nonce size');
-    }
+    this.parents = parents;
+    this.height = height;
+    this.chain = chain;
+    this.timestamp = timestamp;
+    this.body = body;
 
-    if (!content && !encryptedContent) {
-      throw new Error('Either decrypted or encrypted content must be present');
-    }
-
-    if (content && !channel) {
-      throw new Error(
-        '`options.channel` is mandatory when `options.content` is present');
-    }
-
-    if (encryptedContent &&
-        encryptedContent.length < sodium.crypto_secretbox_MACBYTES) {
-      throw new BanError('Invalid encrypted content');
-    }
-
-    this.content = content;
-    this.encryptedContent = encryptedContent;
-
-    this.cachedChain = null;
-
-    // Message MUST have valid hash
-    if (content) {
-      this.encrypt(channel);
-    }
+    this.signature = signature;
 
     this.hash = Buffer.alloc(HASH_SIZE);
     sodium.crypto_generichash(this.hash, this.serializeData());
@@ -71,112 +52,19 @@ export default class Message {
     this.cachedJSON = null;
   }
 
-  get chain() {
-    if (!this.content) {
-      throw new Error('Message must be decrypted first');
-    }
-
-    if (this.cachedChain) {
-      return this.cachedChain;
-    }
-
-    const options = { sodium: this.sodium };
-
-    this.cachedChain = new Chain(
-      this.content.chain.map((link) => Link.deserialize(link, options)));
-    return this.cachedChain;
-  }
-
   get isRoot() {
-    if (!this.content) {
-      throw new Error('Message has not been decrypted');
-    }
-    return !!this.content.body.root;
+    return !!this.body.root;
   }
 
   get json() {
-    if (!this.content) {
-      throw new Error('Message has not been decrypted');
-    }
-
     if (this.isRoot) {
       return undefined;
     }
 
     if (!this.cachedJSON) {
-      this.cachedJSON = JSON.parse(this.content.body.json);
+      this.cachedJSON = JSON.parse(this.body.json);
     }
     return this.cachedJSON;
-  }
-
-  get parents() {
-    if (!this.content) {
-      throw new Error('Message has not been decrypted');
-    }
-
-    return this.content.parents;
-  }
-
-  get height() {
-    if (!this.content) {
-      throw new Error('Message has not been decrypted');
-    }
-
-    // NOTE: Convert Long to Number
-    return typeof this.content.height === 'number' ?
-      this.content.height : this.content.height.toNumber();
-  }
-
-  encrypt(channel) {
-    if (this.encryptedContent) {
-      return;
-    }
-
-    const sodium = this.sodium;
-
-    const cleartext = PChannelMessage.Content.encode(this.content).finish();
-    const ciphertext = Buffer.alloc(
-      cleartext.length + sodium.crypto_secretbox_MACBYTES);
-
-    sodium.crypto_secretbox_easy(ciphertext, cleartext, this.nonce,
-      channel.encryptionKey);
-
-    this.encryptedContent = ciphertext;
-  }
-
-  decrypt(channel) {
-    if (this.content) {
-      return;
-    }
-
-    const sodium = this.sodium;
-
-    const cleartext = Buffer.alloc(this.encryptedContent.length -
-      sodium.crypto_secretbox_MACBYTES);
-    const success = sodium.crypto_secretbox_open_easy(
-      cleartext,
-      this.encryptedContent,
-      this.nonce,
-      channel.encryptionKey);
-    if (!success) {
-      throw new BanError('Failed to decrypt message content');
-    }
-    this.content = PChannelMessage.Content.decode(cleartext);
-
-    this.parents.forEach((hash) => {
-      Message.checkHash(hash, 'Invalid parent hash');
-    });
-    if (this.height < 0) {
-      throw new BanError('Invalid height');
-    }
-
-    if (!this.content.body.root) {
-      try {
-        JSON.parse(this.content.body.json);
-      } catch (e) {
-        throw new BanError('Invalid JSON content. ' + e.message);
-      }
-    }
   }
 
   getAuthor() {
@@ -187,31 +75,19 @@ export default class Message {
   }
 
   verify(channel) {
-    this.decrypt(channel);
-
     const sodium = this.sodium;
     const leafKey = this.chain.getLeafKey(channel);
 
     return sodium.crypto_sign_verify_detached(
-      this.content.signature,
-      Message.tbs({
-        chain: this.content.chain,
-        timestamp: this.content.timestamp,
-        body: this.content.body,
-        parents: this.parents,
-        height: this.height,
-      }),
+      this.signature,
+      Message.tbs(this.serializeTBS()),
       leafKey);
   }
 
   serialize() {
-    if (!this.encryptedContent) {
-      throw new Error('Message has to be encrypted first');
-    }
-
     return {
-      nonce: this.nonce,
-      encryptedContent: this.encryptedContent,
+      tbs: this.serializeTBS(),
+      signature: this.signature,
     };
   }
 
@@ -219,26 +95,34 @@ export default class Message {
     return PChannelMessage.encode(this.serialize()).finish();
   }
 
+  serializeTBS() {
+    return {
+      parents: this.parents,
+      height: this.height,
+      chain: this.chain.serialize(),
+      timestamp: this.timestamp,
+      body: this.body,
+    };
+  }
+
   static deserialize(decoded, options) {
+    const chain = new Chain(
+      decoded.tbs.chain.map((link) => Link.deserialize(link, options)));
+
     return new Message({
       sodium: options.sodium,
-      nonce: decoded.nonce,
-      encryptedContent: decoded.encryptedContent,
+      parents: decoded.tbs.parents,
+      height: decoded.tbs.height.toNumber(),
+      chain,
+      timestamp: decoded.tbs.timestamp,
+      body: decoded.tbs.body,
+
+      signature: decoded.signature,
     });
   }
 
   static deserializeData(data, options) {
     return Message.deserialize(PChannelMessage.decode(data), options);
-  }
-
-  static tbs({ chain, timestamp, body, parents, height }) {
-    return PChannelMessage.Content.TBS.encode({
-      chain,
-      timestamp,
-      body,
-      parents,
-      height,
-    }).finish()
   }
 
   // Helpers
@@ -257,24 +141,14 @@ export default class Message {
     }
   }
 
-  static encryptionKeyFor(channel, height, body) {
-    const sodium = this.sodium;
-
-    const key = Buffer.alloc(sodium.crypto_secretbox_KEYBYTES);
-    sodium.crypto_generichash(key, PChannelMessage.EncryptionKeyInput.encode({
-      channelPubKey: channel.publicKey,
+  static tbs({ chain, timestamp, body, parents, height }) {
+    return PChannelMessage.TBS.encode({
+      chain,
+      timestamp,
+      body,
+      parents,
       height,
-    }).finish(), ENC_KEY);
-    try {
-      body(key);
-    } finally {
-      // Zero key
-      if (sodium.sodium_memzero) {
-        sodium.sodium_memzero(key);
-      } else {
-        key.fill(0);
-      }
-    }
+    }).finish();
   }
 }
 

--- a/lib/protocol/message.js
+++ b/lib/protocol/message.js
@@ -4,7 +4,6 @@ import { ChannelMessage as PChannelMessage } from '../messages';
 import { BanError, now } from '../utils';
 
 import Chain from './chain';
-import Link from './link';
 
 export const HASH_SIZE = 32;
 
@@ -106,8 +105,7 @@ export default class Message {
   }
 
   static deserialize(decoded, options) {
-    const chain = new Chain(
-      decoded.tbs.chain.map((link) => Link.deserialize(link, options)));
+    const chain = Chain.deserialize(decoded.tbs.chain);
 
     return new Message({
       sodium: options.sodium,

--- a/lib/sync-agent.js
+++ b/lib/sync-agent.js
@@ -1,6 +1,7 @@
 import createDebug from 'debug';
 import WaitList from 'promise-waitlist';
 
+import Identity from './protocol/identity';
 import Message from './protocol/message';
 import {
   Packet as PPacket,
@@ -38,6 +39,8 @@ export default class SyncAgent {
       throw new Error('Missing required `socket` option');
     }
 
+    this.destroyed = false;
+
     this.timeoutWaitList = new WaitList();
 
     this.seq = 0;
@@ -47,10 +50,19 @@ export default class SyncAgent {
   }
 
   destroy() {
+    if (this.destroyed) {
+      return;
+    }
+
+    this.destroyed = true;
     this.timeoutWaitList.close(new Error('SyncAgent destroyed'));
   }
 
   async synchronize() {
+    if (this.destroyed) {
+      return;
+    }
+
     this.debug('synchronize() state=%s', this.state);
     if (this.state === 'idle') {
       this.state = 'active';
@@ -198,7 +210,16 @@ export default class SyncAgent {
   // Utils
   //
 
-  async sendAndWait(type, seq, packet) {
+  findIdentityAndChain() {
+    // Do not reveal our identity to feeds
+    // TODO(indutny): document this in protocol.md
+    if (this.channel.isFeed) {
+      return {
+        identity: new Identity('(feed-requestor)', { sodium: this.sodium }),
+        chain: null,
+      };
+    }
+
     // TODO(indutny): this seems somewhat unoptimal?
     const pairs = this.identities.map((identity) => {
       return { identity, chain: identity.getChain(this.channel) };
@@ -210,12 +231,15 @@ export default class SyncAgent {
       }
     });
 
-    // TODO(indutny): cover this in tests
     if (pairs.length === 0) {
       throw new Error('No valid identities to sync to the channel');
     }
 
-    const { identity, chain } = pairs[0];
+    return pairs[0];
+  }
+
+  async sendAndWait(type, seq, packet) {
+    const { identity, chain } = this.findIdentityAndChain();
 
     const queryResponse = new Promise((resolve) => {
       this.pendingRequests.set(seq, {
@@ -237,7 +261,11 @@ export default class SyncAgent {
       syncRequest: {
         channelId: this.channel.id,
         seq,
-        chain: identity.getChain(this.channel).serialize(),
+        ...(chain ? {
+          chain: { links: chain.serialize() },
+        } : {
+          publicKey: identity.publicKey,
+        }),
 
         nonce,
         box,

--- a/lib/sync-agent.js
+++ b/lib/sync-agent.js
@@ -212,7 +212,6 @@ export default class SyncAgent {
 
   findIdentityAndChain() {
     // Do not reveal our identity to feeds
-    // TODO(indutny): document this in protocol.md
     if (this.channel.isFeed) {
       return {
         identity: new Identity('(feed-requestor)', { sodium: this.sodium }),

--- a/lib/sync-agent.js
+++ b/lib/sync-agent.js
@@ -2,7 +2,10 @@ import createDebug from 'debug';
 import WaitList from 'promise-waitlist';
 
 import Message from './protocol/message';
-import { Packet as PPacket } from './messages';
+import {
+  Packet as PPacket,
+  ChannelPacket as PChannelPacket,
+} from './messages';
 import { BanError } from './utils';
 
 const debug = createDebug('vowlink:sync-agent');
@@ -71,8 +74,8 @@ export default class SyncAgent {
     }
   }
 
-  async receiveQuery(query) {
-    this.debug('receiveQuery() seq=%d', query.seq);
+  async receiveQuery(seq, query) {
+    this.debug('receiveQuery() seq=%d', seq);
     const cursor = query.cursor === 'hash' ? { hash: query.hash } :
       { height: query.height };
 
@@ -81,34 +84,44 @@ export default class SyncAgent {
 
     const queryResponse = {
       channelId: query.channelId,
-      seq: query.seq,
       ...result,
     };
 
-    await this.socket.send(PPacket.encode({
+    return PChannelPacket.Content.encode({
       queryResponse,
-    }).finish());
+    }).finish();
   }
 
-  async receiveBulk(bulk) {
-    this.debug('receiveBulk() seq=%d', bulk.seq);
+  async receiveBulk(seq, bulk) {
+    this.debug('receiveBulk() seq=%d', seq);
     const result = await this.channel.bulk(bulk.hashes);
 
     const bulkResponse = {
       channelId: bulk.channelId,
-      seq: bulk.seq,
       messages: result.messages.map((message) => message.serialize()),
       forwardIndex: result.forwardIndex,
     };
 
-    await this.socket.send(PPacket.encode({
+    return PChannelPacket.Content.encode({
       bulkResponse,
-    }).finish());
+    }).finish();
   }
 
-  async receiveQueryResponse(response) {
-    this.debug('receiveQueryResponse() seq=%d', response.seq);
-    const resolve = this.resolveResponse.query.get(response.seq);
+  async receiveEmptyResponse(seq) {
+    this.debug('receiveEmptyResponse() seq=%d', seq);
+
+    const resolve = this.resolveResponse.query.get(seq) ||
+      this.resolveResponse.bulk.get(seq);
+    if (!resolve) {
+      throw new BanError('Unexpected empty response');
+    }
+
+    resolve(null);
+  }
+
+  async receiveQueryResponse(seq, response) {
+    this.debug('receiveQueryResponse() seq=%d', seq);
+    const resolve = this.resolveResponse.query.get(seq);
     if (!resolve) {
       throw new BanError('Unexpected QueryResponse');
     }
@@ -116,9 +129,9 @@ export default class SyncAgent {
     resolve(response);
   }
 
-  async receiveBulkResponse(response) {
-    this.debug('receiveBulkResponse() seq=%d', response.seq);
-    const resolve = this.resolveResponse.bulk.get(response.seq);
+  async receiveBulkResponse(seq, response) {
+    this.debug('receiveBulkResponse() seq=%d', seq);
+    const resolve = this.resolveResponse.bulk.get(seq);
     if (!resolve) {
       throw new BanError('Unexpected BulkResponse');
     }
@@ -140,6 +153,9 @@ export default class SyncAgent {
     }, cursor.hash ? { hash: cursor.hash } : { height: cursor.height });
 
     const response = await this.sendAndWait('query', seq, { query: packet });
+    if (!response) {
+      return { abbreviatedMessages: [], forwardHash: null, backwardHash: null };
+    }
 
     return {
       abbreviatedMessages: response.abbreviatedMessages,
@@ -159,6 +175,9 @@ export default class SyncAgent {
     };
 
     const response = await this.sendAndWait('bulk', seq, { bulk: packet });
+    if (!response) {
+      return { messages: [], forwardIndex: 0 };
+    }
 
     return {
       messages: response.messages.map((decoded) => {
@@ -182,7 +201,18 @@ export default class SyncAgent {
       seq,
       this.resolveResponse[type].size);
 
-    await this.socket.send(PPacket.encode(packet).finish());
+    const clear = PChannelPacket.Content.encode(packet).finish();
+    const { box, nonce } = this.channel.encrypt(clear);
+
+    await this.socket.send(PPacket.encode({
+      channelPacket: {
+        channelId: this.channel.id,
+        seq,
+
+        nonce,
+        box,
+      },
+    }).finish());
 
     const entry = this.timeoutWaitList.waitFor(null, this.options.timeout);
 

--- a/lib/sync-agent.js
+++ b/lib/sync-agent.js
@@ -54,6 +54,7 @@ export default class SyncAgent {
       return;
     }
 
+    this.debug('destroy()');
     this.destroyed = true;
     this.timeoutWaitList.close(new Error('SyncAgent destroyed'));
   }
@@ -238,6 +239,11 @@ export default class SyncAgent {
   }
 
   async sendAndWait(type, seq, packet) {
+    // NOTE: We have no control over channel that syncs using us as remote
+    if (this.destroyed) {
+      throw new Error('Destroyed');
+    }
+
     const { identity, chain } = this.findIdentityAndChain();
 
     const queryResponse = new Promise((resolve) => {
@@ -256,7 +262,10 @@ export default class SyncAgent {
     const clear = PSyncRequest.Content.encode(packet).finish();
     const { box, nonce } = this.channel.encrypt(clear);
 
-    await this.socket.send(PPacket.encode({
+    const entry = this.timeoutWaitList.waitFor(
+      `${type}/${seq}`, this.options.timeout);
+
+    const send = this.socket.send(PPacket.encode({
       syncRequest: {
         channelId: this.channel.id,
         seq,
@@ -271,13 +280,13 @@ export default class SyncAgent {
       },
     }).finish());
 
-    const entry = this.timeoutWaitList.waitFor(null, this.options.timeout);
-
     try {
-      return await Promise.race([
-        queryResponse,
+      const [ _, response ] = await Promise.race([
+        Promise.all([ send, queryResponse ]),
         entry.promise,
       ]);
+
+      return response;
     } finally {
       this.pendingRequests.delete(seq);
       entry.cancel();

--- a/lib/sync-agent.js
+++ b/lib/sync-agent.js
@@ -4,7 +4,7 @@ import WaitList from 'promise-waitlist';
 import Message from './protocol/message';
 import {
   Packet as PPacket,
-  ChannelPacket as PChannelPacket,
+  SyncRequest as PSyncRequest,
 } from './messages';
 import { BanError } from './utils';
 
@@ -22,6 +22,7 @@ export default class SyncAgent {
 
     this.sodium = this.options.sodium;
     this.channel = this.options.channel;
+    this.identities = this.options.identities;
     this.socket = this.options.socket;
 
     if (!this.sodium) {
@@ -30,6 +31,9 @@ export default class SyncAgent {
     if (!this.channel) {
       throw new Error('Missing required `channel` option');
     }
+    if (!this.identities) {
+      throw new Error('Missing required `identities` option');
+    }
     if (!this.socket) {
       throw new Error('Missing required `socket` option');
     }
@@ -37,12 +41,9 @@ export default class SyncAgent {
     this.timeoutWaitList = new WaitList();
 
     this.seq = 0;
-    this.resolveResponse = {
-      // seq => Function
-      query: new Map(),
-      // seq => Function
-      bulk: new Map(),
-    };
+
+    // seq => { type, identity, resolve() }
+    this.pendingRequests = new Map();
   }
 
   destroy() {
@@ -74,6 +75,11 @@ export default class SyncAgent {
     }
   }
 
+  getRequestingIdentity(seq) {
+    const entry = this.pendingRequests.get(seq);
+    return entry && entry.identity;
+  }
+
   async receiveQuery(seq, query) {
     this.debug('receiveQuery() seq=%d', seq);
     const cursor = query.cursor === 'hash' ? { hash: query.hash } :
@@ -87,9 +93,7 @@ export default class SyncAgent {
       ...result,
     };
 
-    return PChannelPacket.Content.encode({
-      queryResponse,
-    }).finish();
+    return { queryResponse };
   }
 
   async receiveBulk(seq, bulk) {
@@ -102,41 +106,44 @@ export default class SyncAgent {
       forwardIndex: result.forwardIndex,
     };
 
-    return PChannelPacket.Content.encode({
-      bulkResponse,
-    }).finish();
+    return { bulkResponse };
   }
 
   async receiveEmptyResponse(seq) {
     this.debug('receiveEmptyResponse() seq=%d', seq);
 
-    const resolve = this.resolveResponse.query.get(seq) ||
-      this.resolveResponse.bulk.get(seq);
-    if (!resolve) {
+    const entry = this.pendingRequests.get(seq);
+    if (!entry) {
       throw new BanError('Unexpected empty response');
     }
 
-    resolve(null);
+    entry.resolve(null);
   }
 
   async receiveQueryResponse(seq, response) {
     this.debug('receiveQueryResponse() seq=%d', seq);
-    const resolve = this.resolveResponse.query.get(seq);
-    if (!resolve) {
+    const entry = this.pendingRequests.get(seq);
+    if (!entry) {
       throw new BanError('Unexpected QueryResponse');
     }
+    if (entry.type !== 'query') {
+      throw new BanError('Expected QueryResponse for this seq');
+    }
 
-    resolve(response);
+    entry.resolve(response);
   }
 
   async receiveBulkResponse(seq, response) {
     this.debug('receiveBulkResponse() seq=%d', seq);
-    const resolve = this.resolveResponse.bulk.get(seq);
-    if (!resolve) {
+    const entry = this.pendingRequests.get(seq);
+    if (!entry) {
       throw new BanError('Unexpected BulkResponse');
     }
+    if (entry.type !== 'bulk') {
+      throw new BanError('Expected BulkResponse for this seq');
+    }
 
-    resolve(response);
+    entry.resolve(response);
   }
 
   //
@@ -192,22 +199,36 @@ export default class SyncAgent {
   //
 
   async sendAndWait(type, seq, packet) {
+    const identity = this.identities.find((id) => {
+      return id.getChain(this.channel);
+    });
+
+    // TODO(indutny): cover this in tests
+    if (!identity) {
+      throw new Error('No valid identities to sync to the channel');
+    }
+
     const queryResponse = new Promise((resolve) => {
-      this.resolveResponse[type].set(seq, resolve);
+      this.pendingRequests.set(seq, {
+        type,
+        identity,
+        resolve,
+      });
     });
 
     this.debug('sendAndWait %s seq=%d waiting=%d',
       type,
       seq,
-      this.resolveResponse[type].size);
+      this.pendingRequests.size);
 
-    const clear = PChannelPacket.Content.encode(packet).finish();
+    const clear = PSyncRequest.Content.encode(packet).finish();
     const { box, nonce } = this.channel.encrypt(clear);
 
     await this.socket.send(PPacket.encode({
-      channelPacket: {
+      syncRequest: {
         channelId: this.channel.id,
         seq,
+        chain: identity.getChain(this.channel),
 
         nonce,
         box,
@@ -222,7 +243,7 @@ export default class SyncAgent {
         entry.promise,
       ]);
     } finally {
-      this.resolveResponse[type].delete(seq);
+      this.pendingRequests.delete(seq);
       entry.cancel();
     }
   }

--- a/lib/sync-agent.js
+++ b/lib/sync-agent.js
@@ -199,14 +199,23 @@ export default class SyncAgent {
   //
 
   async sendAndWait(type, seq, packet) {
-    const identity = this.identities.find((id) => {
-      return id.getChain(this.channel);
+    // TODO(indutny): this seems somewhat unoptimal?
+    const pairs = this.identities.map((identity) => {
+      return { identity, chain: identity.getChain(this.channel) };
+    }).filter(({ chain }) => !!chain).sort((a, b) => {
+      if (a.chain.isBetterThan(b.chain)) {
+        return -1;
+      } else {
+        return 1;
+      }
     });
 
     // TODO(indutny): cover this in tests
-    if (!identity) {
+    if (pairs.length === 0) {
       throw new Error('No valid identities to sync to the channel');
     }
+
+    const { identity, chain } = pairs[0];
 
     const queryResponse = new Promise((resolve) => {
       this.pendingRequests.set(seq, {

--- a/lib/sync-agent.js
+++ b/lib/sync-agent.js
@@ -97,7 +97,8 @@ export default class SyncAgent {
     const bulkResponse = {
       channelId: bulk.channelId,
       seq: bulk.seq,
-      ...result,
+      messages: result.messages.map((message) => message.serialize()),
+      forwardIndex: result.forwardIndex,
     };
 
     await this.socket.send(PPacket.encode({

--- a/lib/sync-agent.js
+++ b/lib/sync-agent.js
@@ -228,7 +228,7 @@ export default class SyncAgent {
       syncRequest: {
         channelId: this.channel.id,
         seq,
-        chain: identity.getChain(this.channel),
+        chain: identity.getChain(this.channel).serialize(),
 
         nonce,
         box,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@vowlink/protocol",
-  "version": "5.0.0-2",
+  "version": "5.0.0-3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@vowlink/protocol",
-  "version": "4.1.0",
+  "version": "5.0.0-0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -565,9 +565,9 @@
       "dev": true
     },
     "eslint": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-6.2.2.tgz",
-      "integrity": "sha512-mf0elOkxHbdyGX1IJEUsNBzCDdyoUgljF3rRlgfyYh0pwGnreLc0jjD6ZuleOibjmnUWZLY2eXwSooeOgGJ2jw==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-6.3.0.tgz",
+      "integrity": "sha512-ZvZTKaqDue+N8Y9g0kp6UPZtS4FSY3qARxBs7p4f0H0iof381XHduqVerFWtK8DPtKmemqbqCFENWSQgPR/Gow==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
@@ -2034,9 +2034,9 @@
       }
     },
     "rxjs": {
-      "version": "6.5.2",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.2.tgz",
-      "integrity": "sha512-HUb7j3kvb7p7eCUHE3FqjoDsC1xfZQ4AHFWfTKSpZ+sAhhz5X1WX0ZuUqWbzB2QhSLp3DoLUG+hMdEDKqWo2Zg==",
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.3.tgz",
+      "integrity": "sha512-wuYsAYYFdWTAnAaPoKGNhfpWwKZbJW+HgAJ+mImp+Epl7BG8oNWBCTyRM8gba9k4lk8BgWdoYm21Mo/RYhhbgA==",
       "dev": true,
       "requires": {
         "tslib": "^1.9.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@vowlink/protocol",
-  "version": "5.0.0-1",
+  "version": "5.0.0-2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@vowlink/protocol",
-  "version": "5.0.0-3",
+  "version": "5.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@vowlink/protocol",
-  "version": "5.0.0-0",
+  "version": "5.0.0-1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vowlink/protocol",
-  "version": "5.0.0-2",
+  "version": "5.0.0-3",
   "description": "VowLink Protocol implementation",
   "main": "lib/protocol.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vowlink/protocol",
-  "version": "5.0.0-1",
+  "version": "5.0.0-2",
   "description": "VowLink Protocol implementation",
   "main": "lib/protocol.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vowlink/protocol",
-  "version": "4.1.0",
+  "version": "5.0.0-0",
   "description": "VowLink Protocol implementation",
   "main": "lib/protocol.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vowlink/protocol",
-  "version": "5.0.0-0",
+  "version": "5.0.0-1",
   "description": "VowLink Protocol implementation",
   "main": "lib/protocol.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vowlink/protocol",
-  "version": "5.0.0-3",
+  "version": "5.0.0",
   "description": "VowLink Protocol implementation",
   "main": "lib/protocol.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "quick-lru": "^4.0.1"
   },
   "devDependencies": {
-    "eslint": "^6.2.2",
+    "eslint": "^6.3.0",
     "esm": "^3.2.25",
     "mocha": "^6.2.0",
     "nyc": "^14.1.1",

--- a/protocol.md
+++ b/protocol.md
@@ -534,30 +534,6 @@ message Notification {
 to notify ALL connected peers that new data is available for the channel. The
 subscribed peers SHOULD attempt to do a synchronization.
 
-## Storage and eviction policies
-
-WIP
-
-The amount of storage SHOULD be configurable in the application (with potential
-notifications for increasing the limit when needed). The split between public
-pool and subscribed feeds MAY be configurable.
-
-Public pool sorts the messages in the order they were received. Duplicates are
-ignored and do not change the order (TODO: reconsider this?). When the available
-storage is exhausted messages are evicted one-by-one until the required amount
-of storage is regained. Public pool SHOULD not evict messages unless needed.
-Public pool SHOULD persist messages between application restarts.
-
-_(TODO(indutny): does 30 day delta mechanism help here?)_
-There is no mechanism for evicting the messages from channels the user is
-subscribed too. However, in the future versions the channel operator MAY be able
-to issue a new channel root from time to time so that past DAGs may be evicted.
-
-## Relays
-
-HTTPS webserver MAY be used as a remote peer to facilitate synchronization
-between peers that are not in vicinity of each other physically.
-
 #### Ideas
 
 *(Something that is not implemented in neither client nor protocol, but might

--- a/protocol.md
+++ b/protocol.md
@@ -8,8 +8,9 @@ The goals of this protocol are:
 1. Provide semi-trusted parties with the means of peer-to-peer communication in
    group chats (channels)
 3. Efficient synchronization of channel messages between semi-trusted peers
-4. Confidentiality of messages. Only past and current channel participants
-   can read the messages. Read and write access has limited timespan
+4. Confidentiality and integrity of messages. Only past and current channel
+   participants can read the messages. Read and write access has limited
+   timespan. Malicious parties cannot modify message content
 5. Eventual consistency. Messages must be viewable offline. New messages can be
    posted offline and distributed once remote peers are available.
 

--- a/protocol.md
+++ b/protocol.md
@@ -576,3 +576,5 @@ be desired)*
 [CRDT]: https://en.wikipedia.org/wiki/Conflict-free_replicated_data_type
 [KDF]: https://signal.org/docs/specifications/doubleratchet/#kdf-chains
 [Noise]: http://noiseprotocol.org/
+[Invite]: #invite
+[Link]: #link

--- a/protocol.md
+++ b/protocol.md
@@ -7,12 +7,9 @@
 The goals of this protocol are:
 1. Provide semi-trusted parties with the means of peer-to-peer communication in
    group chats (channels)
-2. Use untrusted parties that do not participate in the channels as the means
-   of transport of channel messages to interested peers (Mesh network)
-3. Efficient synchronization of channel messages between semi-trusted and
-   untrusted peers
+3. Efficient synchronization of channel messages between semi-trusted peers
 4. Confidentiality of messages. Only past and current channel participants
-   can read the messages.
+   can read the messages. Read and write access has limited timespan
 5. Eventual consistency. Messages must be viewable offline. New messages can be
    posted offline and distributed once remote peers are available.
 

--- a/protocol.md
+++ b/protocol.md
@@ -143,14 +143,11 @@ message ChannelMessage {
 
   message Content {
     message TBS {
-      repeated Link chain = 1;
-      double timestamp = 2;
-      Body body = 3;
-
-      // NOTE: Despite these fields being outside of content they have to be
-      // included here to prevent replay attacks
-      repeated bytes parents = 4;
-      int64 height = 5;
+      repeated bytes parents = 1;
+      int64 height = 2;
+      repeated Link chain = 3;
+      double timestamp = 4;
+      Body body = 5;
     }
 
     // NOTE: can be empty only in the root message

--- a/protocol.md
+++ b/protocol.md
@@ -379,17 +379,20 @@ Unencrypted `Query` is sent in order to request the latest messages from the
 channel:
 ```proto
 message Query {
+  repeated Link chain = 1;
+
   oneof cursor {
-    int64 height = 1;
-    bytes hash = 2;
+    int64 height = 2;
+    bytes hash = 3;
   }
-  bool is_backward = 3;
-  uint32 limit = 4;
+  bool is_backward = 4;
+  uint32 limit = 5;
 }
 ```
 The `query.cursor` MUST be either of `height` or `hash`.
 
-The remote peer responds with:
+If `query.chain` is valid (see [Link][] section above) the remote peer MUST
+respond with:
 ```proto
 message QueryResponse {
   message Abbreviated {
@@ -433,15 +436,18 @@ During synchronization process above the recipient MUST request the messages
 that are not present in their dataset. This can be done with `Bulk` packet:
 ```proto
 message Bulk {
-  repeated bytes hashes = 1;
+  repeated Link chain = 1;
+
+  repeated bytes hashes = 2;
 }
 ```
 
-Remote side SHOULD reply with as many messages as possible. The messages should
-be in the side order as in `bulk.hashes`, except for allowed omissions for
-those hashes that were not found in the datastore or the trailing hashes that
-are omitted due to some constraints. In the latter case `forward_index` MUST be
-set to the number of processes messages:
+If `bulk.chain` is valid (see [Link][] section above) the remote peer MUST
+respond with as many messages as possible, but NOT LESS THAN one. The messages
+should be in the same order as in `bulk.hashes`, except for allowed omissions
+for those hashes that were not found in the datastore or the trailing hashes
+that are omitted due to some constraints. In the latter case `forward_index`
+MUST be set to the number of processes messages:
 ```proto
 message BulkResponse {
   repeated ChannelMessage messages = 1;

--- a/test/channel-test.js
+++ b/test/channel-test.js
@@ -210,6 +210,9 @@ describe('Channel', () => {
       const alt = await Channel.fromIdentity(identity, {
         name: 'test-alt',
         sodium,
+
+        // Make sure that `alt` has different hash
+        timestamp: now() - 3600,
       });
 
       const altRoot = await alt.getRoot();

--- a/test/channel-test.js
+++ b/test/channel-test.js
@@ -40,8 +40,6 @@ describe('Channel', () => {
     return new Message({
       sodium,
       channel,
-      parents: parents.map((p) => p.hash),
-      height,
       content: id.signMessageBody(Message.json(text), channel, {
         height,
         parents: parents.map((p) => p.hash),
@@ -173,9 +171,9 @@ describe('Channel', () => {
       const wrong = new Message({
         sodium,
         channel,
-        parents: [ root.hash ],
-        height: 1,
         content: {
+          parents: [ root.hash ],
+          height: 1,
           chain: [],
           timestamp: now(),
           body: {
@@ -200,8 +198,6 @@ describe('Channel', () => {
       const wrong = new Message({
         sodium,
         channel,
-        parents,
-        height: 1,
         content: identity.signMessageBody(Message.json('wrong'), channel, {
           height: 1,
           parents,
@@ -225,8 +221,6 @@ describe('Channel', () => {
       const wrong = new Message({
         sodium,
         channel,
-        parents: [ altRoot.hash ],
-        height: 1,
         content: identity.signMessageBody(Message.json('wrong'), channel, {
           height: 1,
           parents: [ altRoot.hash ],
@@ -292,8 +286,6 @@ describe('Channel', () => {
       const invalid = new Message({
         sodium,
         channel,
-        parents: [ root.hash ],
-        height: 1,
         content: identity.signMessageBody(Message.root(), channel, {
           height: 1,
           parents: [ root.hash ],

--- a/test/identity-test.js
+++ b/test/identity-test.js
@@ -2,6 +2,7 @@
 import * as assert from 'assert';
 import * as sodium from 'sodium-universal';
 
+import { now } from '../lib/utils';
 import { Chain, Channel, Identity, Message } from '../';
 
 describe('Identity', () => {
@@ -36,5 +37,10 @@ describe('Identity', () => {
     assert.deepStrictEqual(copy.getMetadata(), { ok: true });
 
     await channel.post(Message.json('test'), copy);
+
+    assert.strictEqual(trustee.getChannelIds(now() + 1e9).length, 0);
+    assert.strictEqual(trustee.getChain(channel, now() + 1e9), false);
+    assert.strictEqual(identity.getChain(channel, now() + 1e9),
+      identity.getChain(channel));
   });
 });

--- a/test/message-test.js
+++ b/test/message-test.js
@@ -36,8 +36,6 @@ describe('Message', () => {
     const message = new Message({
       sodium,
       channel,
-      parents: [],
-      height: 0,
       content,
     });
     assert.ok(message.verify(channel));
@@ -45,8 +43,6 @@ describe('Message', () => {
     const copy = new Message({
       sodium,
       channelId: channel.id,
-      parents: [],
-      height: 0,
       nonce: message.nonce,
       encryptedContent: message.encryptedContent,
     });
@@ -60,8 +56,6 @@ describe('Message', () => {
     const invalid = new Message({
       sodium,
       channelId: channel.id,
-      parents: [],
-      height: 0,
       // NOTE: Random nonce here
       nonce: null,
       encryptedContent: message.encryptedContent,
@@ -95,8 +89,6 @@ describe('Message', () => {
     const message = new Message({
       sodium,
       channel,
-      parents: [],
-      height: 0,
       content,
     });
     assert.ok(message.verify(channel));
@@ -117,20 +109,17 @@ describe('Message', () => {
     const message = new Message({
       sodium,
       channel,
-      parents: [],
-      height: 1,
       content,
     });
 
     const data = message.serializeData();
     const copy = Message.deserializeData(data, { sodium });
-    assert.strictEqual(copy.channelId.toString('hex'),
-      message.channelId.toString('hex'));
-    assert.strictEqual(copy.height, message.height);
-    assert.strictEqual(copy.parents.length, message.parents.length);
 
     // Should not throw
     copy.decrypt(channel);
+
+    assert.strictEqual(copy.height, message.height);
+    assert.strictEqual(copy.parents.length, message.parents.length);
   });
 
   it('should throw on decrypting bad JSON', () => {
@@ -145,8 +134,6 @@ describe('Message', () => {
     const message = new Message({
       sodium,
       channel,
-      parents: [],
-      height: 1,
       content,
     });
 

--- a/test/protocol-test.js
+++ b/test/protocol-test.js
@@ -135,7 +135,10 @@ describe('Protocol', () => {
   });
 
   it('should sync read-only channels', async () => {
-    const [ idA, channelA ] = await a.createIdentityPair('a');
+    const [ idA, channelA ] = await a.createIdentityPair('a', {
+      isFeed: true,
+    });
+    assert.ok(channelA.isFeed);
     const [ idB, _ ] = await b.createIdentityPair('b');
 
     const run = async () => {
@@ -144,7 +147,9 @@ describe('Protocol', () => {
 
       const readonly = await b.channelFromPublicKey(channelA.publicKey, {
         name: 'readonly',
+        isFeed: true,
       });
+      assert.ok(readonly.isFeed);
       assert.ok(!idB.canInvite(readonly));
       assert.ok(!idB.canPost(readonly));
 

--- a/test/protocol-test.js
+++ b/test/protocol-test.js
@@ -147,7 +147,6 @@ describe('Protocol', () => {
 
       const readonly = await b.channelFromPublicKey(channelA.publicKey, {
         name: 'readonly',
-        isFeed: true,
       });
       assert.ok(readonly.isFeed);
       assert.ok(!idB.canInvite(readonly));

--- a/test/protocol-test.js
+++ b/test/protocol-test.js
@@ -145,7 +145,7 @@ describe('Protocol', () => {
       // Post a message
       await channelA.post(Message.json('ohai'), idA);
 
-      const readonly = await b.channelFromPublicKey(channelA.publicKey, {
+      const readonly = await b.feedFromPublicKey(channelA.publicKey, {
         name: 'readonly',
       });
       assert.ok(readonly.isFeed);


### PR DESCRIPTION
Major changes:

* Remove encryption from individual messages
* Add encryption to synchronization requests
* Encrypt synchronization responses with the `publicKey` of requestor
* Validate and use `publicKey` from requstor's chain (control read and write access to channel)
* Allow public read access to channels with `.isFeed = true`.